### PR TITLE
Feat/#43/음성 검색 뷰에서 마이크버튼 기능 추가

### DIFF
--- a/BusRoad/Feature/VoiceSearch/VoiceSearchView+Actions.swift
+++ b/BusRoad/Feature/VoiceSearch/VoiceSearchView+Actions.swift
@@ -5,7 +5,11 @@ extension VoiceSearchView {
         switch vm.state {
         case .ready, .failed:
             vm.retry()
-        case .listening, .processing, .completed:
+            
+        case .listening:
+            vm.cancelListening()
+            
+        case .processing, .completed:
             break
         }
     }

--- a/BusRoad/Feature/VoiceSearch/VoiceSearchViewModel.swift
+++ b/BusRoad/Feature/VoiceSearch/VoiceSearchViewModel.swift
@@ -71,6 +71,20 @@ final class VoiceSearchViewModel: ObservableObject {
     }
     
     
+    /// 음성 인식 중단 (사용자가 직접 중단)
+    func cancelListening() {
+        
+        speechManager.stopRecording()
+        
+        recognizedText = ""
+        lastTranscript = ""
+        
+        state = .ready
+        
+        errorMessage = nil
+    }
+    
+    
     // MARK: - 프라이빗 메서드들
     private func setupSpeechManager() {
         // 녹음 상태
@@ -167,6 +181,6 @@ extension VoiceSearchViewModel {
     
     /// 마이크 버튼 활성화 여부
     var isMicButtonEnabled: Bool {
-        return state == .ready || state == .failed
+        return state == .ready || state == .failed || state == .listening
     }
 }


### PR DESCRIPTION
## #️⃣ 관련 이슈
> closes #43 

---

## 💻 작업 내용

> 음성검색에서 .listening 상태인 경우에도 버튼이 동작하도록 했습니다. 
- .processing 으로 넘어가지 않았을때 버튼을 클릭하는경우 .failed로 넘어가게됩니다. 

---

## 📝 코드 설명

> 마이크 활성화 상태에 .listening을 추가하고, .listening 중에 사용자가 버튼을 누를경우, 음성인식이 중단되고, 인식되었던 텍스트가 비워지도록 하는 cancelListening()을 handleMicButtonTap()에 추가했습니다.


---

## 🙋 리뷰 요구사항

>  코드 확인 부탁드립니다:)

---

## ✋🏻 잠깐! 확인하셨나요?
- [x] 컨벤션 확인
- [x] 기능 정상 작동 테스트 완료
- [x] 디버깅 코드 및 주석 제거
- [x] 사용하지 않는 코드/파일 정리
- [x] 작업 내용 및 코드 설명 작성 

