### PR TITLE
Feat/#71/alert

### DIFF
--- a/BusRoad/Component/StopNavigationAlert.swift
+++ b/BusRoad/Component/StopNavigationAlert.swift
@@ -19,21 +19,21 @@ struct StopNavigationAlert: View {
           .ignoresSafeArea()
         
         Rectangle()
-          .frame(width: 300, height: 199)
+          .frame(width: 300.wScaled, height: 199.wScaled)
           .cornerRadius(35)
           .foregroundColor(Color.background)
-        VStack(alignment:.center, spacing: 16){
+        VStack(alignment:.center, spacing: 16.wScaled){
           Text("경로 안내를 종료할까요?")
-            .font(.presemi24)
+            .font(.presemi24Scaled)
             .foregroundColor(.primary)
-            .padding(.leading, 8)
+            .padding(.leading, 8.wScaled)
           Text("페이지를 종료하면 경로 안내가\n종료돼요.")
-            .font(.prereg20)
+            .font(.prereg20Scaled)
             .foregroundColor(.primary)
-            .lineSpacing(5)
+            .lineSpacing(5.wScaled)
             .multilineTextAlignment(.leading)
-            .padding(.leading, 8)
-          HStack(spacing: 16){
+            .padding(.leading, 8.wScaled)
+          HStack(spacing: 16.wScaled){
             Button{
               isPresented = false
             } label:{
@@ -41,10 +41,10 @@ struct StopNavigationAlert: View {
                 Rectangle()
                   .cornerRadius(100)
                   .foregroundColor(Color.primaryLight)
-                  .frame(width: 128, height: 48)
+                  .frame(width: 128.wScaled, height: 48.wScaled)
                 Text("닫기")
                   .foregroundColor(Color.greyStrong)
-                  .font(.premed20)
+                  .font(.premed20Scaled)
               }
             }
             Button{
@@ -55,10 +55,10 @@ struct StopNavigationAlert: View {
                 Rectangle()
                   .cornerRadius(100)
                   .foregroundColor(Color.cancelbutton)
-                  .frame(width: 128, height: 48)
+                  .frame(width: 128.wScaled, height: 48.wScaled)
                 Text("종료하기")
                   .foregroundColor(Color.subLight)
-                  .font(.premed20)
+                  .font(.premed20Scaled)
               }
             }
           }

--- a/BusRoad/Component/WalkingView/WalkingAlert.swift
+++ b/BusRoad/Component/WalkingView/WalkingAlert.swift
@@ -18,21 +18,21 @@ struct WalkingAlert: View {
           .ignoresSafeArea()
         
         Rectangle()
-          .frame(width: 300, height: 199)
+          .frame(width: 300.wScaled, height: 199.wScaled)
           .cornerRadius(35)
           .foregroundColor(Color.background)
-        VStack(alignment:.center, spacing: 16){
+        VStack(alignment:.center, spacing: 16.wScaled){
           Text("혹시 이미 도착하셨나요?")
-            .font(.presemi24)
+            .font(.presemi24Scaled)
             .foregroundColor(.primary)
-            .padding(.leading, 8)
+            .padding(.leading, 8.wScaled)
           Text("목적지에 이미 도착하셨다면,\n직접 완료할 수 있어요.")
-            .font(.prereg20)
+            .font(.prereg20Scaled)
             .foregroundColor(.primary)
-            .lineSpacing(5)
+            .lineSpacing(5.wScaled)
             .multilineTextAlignment(.leading)
-            .padding(.leading, 8)
-          HStack(spacing: 16){
+            .padding(.leading, 8.wScaled)
+          HStack(spacing: 16.wScaled){
             Button{
               isPresented = false
             } label:{
@@ -40,10 +40,10 @@ struct WalkingAlert: View {
                 Rectangle()
                   .cornerRadius(100)
                   .foregroundColor(Color.primaryLight)
-                  .frame(width: 128, height: 48)
+                  .frame(width: 128.wScaled, height: 48.wScaled)
                 Text("닫기")
                   .foregroundColor(Color.greyStrong)
-                  .font(.premed20)
+                  .font(.premed20Scaled)
               }
             }
             Button{
@@ -54,10 +54,10 @@ struct WalkingAlert: View {
                 Rectangle()
                   .cornerRadius(100)
                   .foregroundColor(Color.subPoint)
-                  .frame(width: 128, height: 48)
+                  .frame(width: 128.wScaled, height: 48.wScaled)
                 Text("완료하기")
                   .foregroundColor(Color.primarywhite)
-                  .font(.premed20)
+                  .font(.premed20Scaled)
               }
             }
           }

--- a/BusRoad/Component/WholeJourney/TopBar.swift
+++ b/BusRoad/Component/WholeJourney/TopBar.swift
@@ -18,10 +18,10 @@ struct TopBar: View {
         Spacer()
         if isMoving {
           Text("경로 이동")
-            .font(.papermed18)
+            .font(.papermed18Scaled)
         } else {
           Text("경로 탐색")
-            .font(.papermed18)
+            .font(.papermed18Scaled)
         }
         Spacer()
       }
@@ -39,7 +39,7 @@ struct TopBar: View {
           Image("xbutton")
             .resizable()
             .aspectRatio(contentMode: .fit)
-            .frame(width:44, height:44)
+            .frame(width:44.wScaled, height:44.wScaled)
             .foregroundColor(.greyNormal)
         }
       }

--- a/BusRoad/Feature/Walking/WalkingView.swift
+++ b/BusRoad/Feature/Walking/WalkingView.swift
@@ -29,18 +29,18 @@ struct WalkingView: View {
       
       VStack(spacing: 0){
         
-        VStack(spacing: 32) {
+        VStack(spacing: 32.wScaled) {
           TopBar(isMoving: true) { coordinator.popToRoot() }
-            .padding(.horizontal, 8)
+            .padding(.horizontal, 8.wScaled)
           
           if let journey, let index {
             WholeJourney(journey: journey, journeyIndex: index, isBeforeRide: false)
-              .padding(.horizontal, 32)
+              .padding(.horizontal, 32.wScaled)
           }
           
           LineDivider()
         }
-        .frame(height: 144)
+        .frame(height: 144.wScaled)
         
         ZStack {
           Color(.background)
@@ -58,7 +58,7 @@ struct WalkingView: View {
                 Button("이미 목적지에 도착하셨나요?") {
                   showAlert = true
                 }
-                .font(.premed12)
+                .font(.premed12Scaled)
                 .foregroundColor(.primaryHeavy)
                 .underline()
                 


### PR DESCRIPTION
## #️⃣ 관련 이슈
> closes #71 

---

## 💻 작업 내용

> 도보 이동 중 목적지에 이미 도착하였을 시, 다음 단계로 넘어가는 Alert를 구현하였습니다.
경로 진행 중 종료 버튼(상단 x 버튼) 누를 시, Alert가 발생하도록 구현하였습니다.

---

## 📝 코드 설명

> topbar에 기존에 x버튼이 있어 거기에 StopNavigationAlert이 연결되도록 하였고, topbar는 상단에만 보이기 때문에 fullscreencover를 사용해서 alert은 전체 화면에 구현되도록 했습니다. fullscreencover에 기본적으로 있는 애니메이션은 제거했습니다.
도보 이동에서 alert-완료하기 버튼을 누르면 journey 다음 node로 넘어가도록 구현하였습니다. (환승 필요 시 - 승차 전 카드, 목적지 도착 시- 도착 축하 카드)

---

## 🙋 리뷰 요구사항

> 특별히 이상은 없을 것 같습니다. (제발)

---

## 📁 참고한 내용 (선택)
* (주소 첨부)
* 
---

## ✋🏻 잠깐! 확인하셨나요?
- [ ] 컨벤션 확인
- [ ] 기능 정상 작동 테스트 완료
- [ ] 디버깅 코드 및 주석 제거
- [ ] 사용하지 않는 코드/파일 정리
- [ ] 작업 내용 및 코드 설명 작성 

