### PR TITLE
[QA] 알러트 수정

### DIFF
--- a/BusRoad/Component/StopNavigationAlert.swift
+++ b/BusRoad/Component/StopNavigationAlert.swift
@@ -16,34 +16,30 @@ struct StopNavigationAlert: View {
     if isPresented {
       ZStack {
         Color.black
+              .opacity(0.5)
           .ignoresSafeArea()
-        
-        Rectangle()
-          .frame(width: 300.wScaled, height: 199.wScaled)
-          .cornerRadius(35)
-          .foregroundColor(Color.background)
-        VStack(alignment:.center, spacing: 16.wScaled){
+        VStack(alignment:.center){
           Text("경로 안내를 종료할까요?")
             .font(.presemi24Scaled)
             .foregroundColor(.primary)
-            .padding(.leading, 8.wScaled)
-          Text("페이지를 종료하면 경로 안내가\n종료돼요.")
+            .padding(.top, 18.wScaled)
+            .padding(.bottom, 10.wScaled)
+          Text("페이지를 나가면\n경로 안내가 종료돼요.")
             .font(.prereg20Scaled)
             .foregroundColor(.primary)
-            .lineSpacing(5.wScaled)
-            .multilineTextAlignment(.leading)
-            .padding(.leading, 8.wScaled)
-          HStack(spacing: 16.wScaled){
+           .multilineTextAlignment(.center)
+           .padding(.bottom, 24.wScaled)
+          HStack(spacing: 10.wScaled){
             Button{
               isPresented = false
             } label:{
               ZStack{
                 Rectangle()
                   .cornerRadius(100)
-                  .foregroundColor(Color.primaryLight)
-                  .frame(width: 128.wScaled, height: 48.wScaled)
+                  .foregroundColor(Color.greybutton.opacity(0.2))
+                  .frame(width: 139.wScaled, height: 48.wScaled)
                 Text("닫기")
-                  .foregroundColor(Color.greyStrong)
+                  .foregroundColor(Color.black)
                   .font(.premed20Scaled)
               }
             }
@@ -55,7 +51,7 @@ struct StopNavigationAlert: View {
                 Rectangle()
                   .cornerRadius(100)
                   .foregroundColor(Color.cancelbutton)
-                  .frame(width: 128.wScaled, height: 48.wScaled)
+                  .frame(width: 139.wScaled, height: 48.wScaled)
                 Text("종료하기")
                   .foregroundColor(Color.subLight)
                   .font(.premed20Scaled)
@@ -63,7 +59,17 @@ struct StopNavigationAlert: View {
             }
           }
         }
-        .padding()
+        .padding(.vertical, 15.wScaled)
+        .frame(width: 320.wScaled)
+        .background(
+            RoundedRectangle(cornerRadius: 35)
+            .fill(.regularMaterial)
+            .overlay(
+              RoundedRectangle(cornerRadius: 35)
+                .stroke(Color.primarywhite, lineWidth: 0.5)
+            )
+        )
+          
       }
       .background(.clear)
     }

--- a/BusRoad/Component/WalkingView/WalkingAlert.swift
+++ b/BusRoad/Component/WalkingView/WalkingAlert.swift
@@ -15,34 +15,31 @@ struct WalkingAlert: View {
     if isPresented {
       ZStack {
         Color.black
+              .opacity(0.5)
           .ignoresSafeArea()
         
-        Rectangle()
-          .frame(width: 300.wScaled, height: 199.wScaled)
-          .cornerRadius(35)
-          .foregroundColor(Color.background)
-        VStack(alignment:.center, spacing: 16.wScaled){
-          Text("혹시 이미 도착하셨나요?")
+        VStack(alignment:.center){
+          Text("목적지에 도착하셨나요?")
             .font(.presemi24Scaled)
             .foregroundColor(.primary)
-            .padding(.leading, 8.wScaled)
-          Text("목적지에 이미 도착하셨다면,\n직접 완료할 수 있어요.")
+            .padding(.top, 18.wScaled)
+            .padding(.bottom, 10.wScaled)
+          Text("목적지에 이미 도착하셨다면,\n직접 경로를 완료할 수 있어요.")
             .font(.prereg20Scaled)
             .foregroundColor(.primary)
-            .lineSpacing(5.wScaled)
-            .multilineTextAlignment(.leading)
-            .padding(.leading, 8.wScaled)
-          HStack(spacing: 16.wScaled){
+            .multilineTextAlignment(.center)
+            .padding(.bottom, 24.wScaled)
+          HStack(spacing: 10.wScaled){
             Button{
               isPresented = false
             } label:{
               ZStack{
                 Rectangle()
                   .cornerRadius(100)
-                  .foregroundColor(Color.primaryLight)
-                  .frame(width: 128.wScaled, height: 48.wScaled)
+                  .foregroundColor(Color.greybutton.opacity(0.2))
+                  .frame(width: 139.wScaled, height: 48.wScaled)
                 Text("닫기")
-                  .foregroundColor(Color.greyStrong)
+                  .foregroundColor(Color.black)
                   .font(.premed20Scaled)
               }
             }
@@ -54,7 +51,7 @@ struct WalkingAlert: View {
                 Rectangle()
                   .cornerRadius(100)
                   .foregroundColor(Color.subPoint)
-                  .frame(width: 128.wScaled, height: 48.wScaled)
+                  .frame(width: 139.wScaled, height: 48.wScaled)
                 Text("완료하기")
                   .foregroundColor(Color.primarywhite)
                   .font(.premed20Scaled)
@@ -62,8 +59,19 @@ struct WalkingAlert: View {
             }
           }
         }
-        .padding()
+        .padding(.vertical, 15.wScaled)
+        .frame(width: 320.wScaled)
+          
+        .background(
+            RoundedRectangle(cornerRadius: 35)
+            .fill(.regularMaterial) // 내부 색상
+            .overlay(
+                RoundedRectangle(cornerRadius: 35)
+                    .stroke(Color.primarywhite, lineWidth: 0.5)
+                    )
+        )
       }
+      .background(.clear)
     }
   }
 }

--- a/BusRoad/Resource/Color.xcassets/greybutton.colorset/Contents.json
+++ b/BusRoad/Resource/Color.xcassets/greybutton.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x80",
+          "green" : "0x78",
+          "red" : "0x78"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
도보 뷰 하단 버튼 알러트
x버튼 알러트 디자인 수정

## #️⃣ 관련 이슈
> closes #86 

---

## 💻 작업 내용

> 알러트창 배경 black oppacity적용, 알러트 창 사이즈 및 컬러 수정, 텍스트 중앙정렬

<img width="200"  alt="image" src="https://github.com/user-attachments/assets/efcc62b8-9316-4a39-ba4c-02d58ec316f3" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/101422da-bdd8-4b67-9892-2187bcd4835d" />


---

## 📝 코드 설명

> regularMaterial 색상 사용, buttongery추가
기존 코드가 렉텡귤이 상위에 지정되어있어서 패딩이 따로 놀아서

수정하면서 프레임을 주고 백그라운드로 라운드 랙탱귤 주는 방식으로 코드 수정했습니다
---

## 🙋 리뷰 요구사항
-
---

## 📁 참고한 내용 (선택)
* (주소 첨부)
* 
---

## ✋🏻 잠깐! 확인하셨나요?
- [ ] 컨벤션 확인
- [ ] 기능 정상 작동 테스트 완료
- [ ] 디버깅 코드 및 주석 제거
- [ ] 사용하지 않는 코드/파일 정리
- [ ] 작업 내용 및 코드 설명 작성 

