### PR TITLE
[fix]#84 음성검색 감지 시간 수정

### DIFF
--- a/BusRoad/Utility/Manager/SpeechRecognitionManager.swift
+++ b/BusRoad/Utility/Manager/SpeechRecognitionManager.swift
@@ -21,7 +21,9 @@ class SpeechRecognitionManager: ObservableObject {
     
     // 침묵 감지를 위한 타이머
     private var silenceTimer: Timer?
-    private let silenceThreshold: TimeInterval = 3.0 // 3초
+    private let initialSilenceThreshold: TimeInterval = 3.0// 첫 입력 대기시간
+    private let subsequentSilenceThreshold: TimeInterval = 0.5 // 침묵 이후 감지 시간
+    private var hasReceivedFirstResult = false // 첫 음성 입력 받았는지 여부
     
     // MARK: - 초기화
     init() {
@@ -71,7 +73,9 @@ class SpeechRecognitionManager: ObservableObject {
     func reset() {
         stopRecording()
         recognizedText = ""
+        hasReceivedFirstResult = false
         errorMessage = nil
+        print("[Speech] 완전 초기화")
     }
 }
 
@@ -159,6 +163,7 @@ private extension SpeechRecognitionManager {
         isRecording = true
         recognizedText = ""
         errorMessage = nil
+        hasReceivedFirstResult = false
 
         startSilenceTimer()
     }
@@ -173,8 +178,15 @@ private extension SpeechRecognitionManager {
         if let result = result {
             recognizedText = result.bestTranscription.formattedString
             
+            // 처음 버튼 누르고 난 후
+            if !hasReceivedFirstResult && !recognizedText.isEmpty {
+                hasReceivedFirstResult = true
+                print("[Speech] 첫 음성인식 완료, 빠른 침묵 감지 모드로 전환")
+            }
+            
             // 최종 결과가 나왔으면 타이머 재시작, 아니면 계속 진행
             if result.isFinal {
+                print("[Speech] 최종결과 수신, 녹음 중지")
                 stopRecording()
             } else {
                 restartSilenceTimer()
@@ -184,8 +196,13 @@ private extension SpeechRecognitionManager {
     
     /// 침묵 타이머 시작
     func startSilenceTimer() {
-        silenceTimer = Timer.scheduledTimer(withTimeInterval: silenceThreshold, repeats: false) { [weak self] _ in
+        let threshold = hasReceivedFirstResult ? subsequentSilenceThreshold : initialSilenceThreshold
+        
+        print("[Speech] 침묵 타이머 시작 - \(threshold)초 대기 (첫입력: \(!hasReceivedFirstResult))")
+        
+        silenceTimer = Timer.scheduledTimer(withTimeInterval: threshold, repeats: false) { [weak self] _ in
             Task { @MainActor in
+                print("[Speech] 침묵감지 -> 녹음 자동 중지")
                 self?.stopRecording()
             }
         }
@@ -194,6 +211,7 @@ private extension SpeechRecognitionManager {
     /// 침묵 타이머 재시작
     func restartSilenceTimer() {
         silenceTimer?.invalidate()
+        print("[Speech] 음성 입력 감지 → 타이머 재시작")
         startSilenceTimer()
     }
     


### PR DESCRIPTION
## #️⃣ 관련 이슈
> closes #84 

---

## 💻 작업 내용

> 음성검색에서 발생하던 시간 지연 문제를 해결했습니다. 

---

## 📝 코드 설명

> SpeechManager에서 음성 첫 진입시와 음성인식 후에 타이머 시간을 나눴습니다. 
처음 진입했을때는 3초동안 음성인식이 켜져있고, 아무런 인식이 자동으로 꺼집니다. 
음성검색후에는 0.5초후 검색화면으로 넘어갑니다. 
혹시 나중을 위한 디버깅용 print도 넣어놨습니다. 

---

## 🙋 리뷰 요구사항

> 코드 확인 부탁드립니다:) 

---

## ✋🏻 잠깐! 확인하셨나요?
- [x] 컨벤션 확인
- [x] 기능 정상 작동 테스트 완료
- [x] 디버깅 코드 및 주석 제거
- [x] 사용하지 않는 코드/파일 정리
- [x] 작업 내용 및 코드 설명 작성 

