### PR TITLE
[fix]#91 장소검색 리스트 텍스트 라인 최대 2줄

### DIFF
--- a/BusRoad/Component/MainSearchView/PlaceCard.swift
+++ b/BusRoad/Component/MainSearchView/PlaceCard.swift
@@ -12,24 +12,26 @@ struct PlaceCard: View {
                 
                 if let query = searchQuery, !query.isEmpty {
                     Text(title.highlightedText(searchQuery: query))
-                        .lineLimit(1)
+                        .lineLimit(2)
                         .truncationMode(.tail)
                         .font(.presemi24)
                         .foregroundStyle(.primaryHeavy)
+                        .fixedSize(horizontal: false, vertical: true)
                     
                     
                 } else {
                     Text(title)
                         .font(.presemi24)
                         .foregroundStyle(.primaryHeavy)
-                        .lineLimit(1)
+                        .lineLimit(2)
                         .truncationMode(.tail)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
 
                 Text(address)
                     .font(.prereg18)
                     .foregroundStyle(.greyNormal)
-                    .lineLimit(1)
+                    .lineLimit(2)
                     .truncationMode(.tail)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -86,13 +88,13 @@ extension String {
 #Preview {
     VStack(spacing: 7) {
         PlaceCard(
-            title: "포항 영일대해수욕장",
-            address: "경북 포항시 북구 두호동 685",
+            title: "포항 공과대학교 박태준 학술정보관",
+            address: "경기도 용인시 처인구 중부대로 1440번길 7 303호",
             searchQuery: "포항",
             onTap: {}
         )
         PlaceCard(
-            title: "테라로사 포스텍점",
+            title: "가나다라마바사아자차카타파하아에이오우",
             address: "포항시 남구 청암로 87",
             searchQuery: "포항",
             onTap: {}


### PR DESCRIPTION
## #️⃣ 관련 이슈
> closes #91 

---

## 💻 작업 내용

> 검색 리스트에서 장소명과 주소명이 최대 2줄로 뜨도록 수정했습니다

---

## 📝 코드 설명

> linelimit만 수정되었습니다. 

---

## 🙋 리뷰 요구사항

> 코드 확인 부탁드려요!
---

## ✋🏻 잠깐! 확인하셨나요?
- [x] 컨벤션 확인
- [x] 기능 정상 작동 테스트 완료
- [x] 디버깅 코드 및 주석 제거
- [x] 사용하지 않는 코드/파일 정리
- [x] 작업 내용 및 코드 설명 작성 

