### PR TITLE
QA 디자인 반영

### DIFF
--- a/BusRoad/Component/StopNavigationAlert.swift
+++ b/BusRoad/Component/StopNavigationAlert.swift
@@ -22,16 +22,16 @@ struct StopNavigationAlert: View {
           Text("경로 안내를 종료할까요?")
             .font(.presemi24Scaled)
             .foregroundColor(.primaryblack)
-            .padding(.top, 18.wScaled)
+            .padding(.top, 20.wScaled)
             .padding(.bottom, 10.wScaled)
             
-          Text("페이지를 나가면\n경로 안내가 종료돼요.")
+          Text("페이지를 나가면 경로 안내가\n종료돼요.")
             .font(.prereg20Scaled)
             .foregroundColor(.primaryblack)
            .multilineTextAlignment(.center)
-           .padding(.bottom, 24.wScaled)
+           .padding(.bottom, 36.wScaled)
             
-          HStack(spacing: 10.wScaled){
+          HStack(spacing: 9.wScaled){
             Button{
               isPresented = false
             } label:{
@@ -40,7 +40,7 @@ struct StopNavigationAlert: View {
                   .cornerRadius(100)
                   .foregroundColor(Color.greybutton)
                   .frame(width: 139.wScaled, height: 48.wScaled)
-                Text("닫기")
+                Text("취소")
                   .foregroundColor(Color.primaryblack)
                   .font(.premed20Scaled)
               }
@@ -61,7 +61,7 @@ struct StopNavigationAlert: View {
             }
           }
         }
-        .padding(.vertical, 15.wScaled)
+        .padding(.vertical, 20.wScaled)
         .frame(width: 320.wScaled)
         .background(
             RoundedRectangle(cornerRadius: 35)

--- a/BusRoad/Component/WalkingView/WalkingAlert.swift
+++ b/BusRoad/Component/WalkingView/WalkingAlert.swift
@@ -22,16 +22,10 @@ struct WalkingAlert: View {
           Text("목적지에 도착하셨나요?")
             .font(.presemi24Scaled)
             .foregroundColor(.primaryblack)
-            .padding(.top, 18.wScaled)
-            .padding(.bottom, 10.wScaled)
+            .padding(.top, 20.wScaled)
+            .padding(.bottom, 36.wScaled)
             
-          Text("목적지에 이미 도착하셨다면,\n직접 경로를 완료할 수 있어요.")
-            .font(.prereg20Scaled)
-            .foregroundColor(.primaryblack)
-            .multilineTextAlignment(.center)
-            .padding(.bottom, 24.wScaled)
-            
-          HStack(spacing: 10.wScaled){
+          HStack(spacing: 9.wScaled){
             Button{
               isPresented = false
             } label:{
@@ -40,7 +34,7 @@ struct WalkingAlert: View {
                   .cornerRadius(100)
                   .foregroundColor(Color.greybutton)
                   .frame(width: 139.wScaled, height: 48.wScaled)
-                Text("닫기")
+                Text("아니요")
                   .foregroundColor(Color.primaryblack)
                   .font(.premed20Scaled)
               }
@@ -54,14 +48,14 @@ struct WalkingAlert: View {
                   .cornerRadius(100)
                   .foregroundColor(Color.subPoint)
                   .frame(width: 139.wScaled, height: 48.wScaled)
-                Text("완료하기")
+                Text("네")
                   .foregroundColor(Color.primarywhite)
                   .font(.premed20Scaled)
               }
             }
           }
         }
-        .padding(.vertical, 15.wScaled)
+        .padding(.vertical, 20.wScaled)
         .frame(width: 320.wScaled)
           
         .background(


### PR DESCRIPTION
알러트 디자인 수정

## #️⃣ 관련 이슈
> closes #99 

---

## 💻 작업 내용

> <img width="200"  alt="IMG_4882" src="https://github.com/user-attachments/assets/685ebd8f-42ca-44ba-b489-d054f9b6818d" /> <img width="200"  alt="IMG_4883" src="https://github.com/user-attachments/assets/b874098b-7487-46f0-ad9d-1deffb0ccb70" />

---

## 📝 코드 설명

> QA디자인 반영했습니다.


---

## 🙋 리뷰 요구사항

> 현재 "목적지에 도착하셨나요" 부분은 텍스트 부분은 기존대로 해두었습니다

(클로이 QA : 환승 도보 일때는 "정류장에 도착하셨나요?", 최종 도보 일때는 "목적지~"
-> 그래서 도보뷰에서 언더라인 텍스트도 두 경우(환승도보, 최종도보)에 따라 내용이 바뀌고, 
누르면 각각의 알러트에 연결되어야해서 개발자 분들과 이야기 필요!)

---

## 📁 참고한 내용 (선택)
* (주소 첨부)
* 
---

## ✋🏻 잠깐! 확인하셨나요?
- [ ] 컨벤션 확인
- [ ] 기능 정상 작동 테스트 완료
- [ ] 디버깅 코드 및 주석 제거
- [ ] 사용하지 않는 코드/파일 정리
- [ ] 작업 내용 및 코드 설명 작성 

