### PR TITLE
Style/#108/출발지 검색 텍스트 필드 컬러수정

### DIFF
--- a/BusRoad/Component/RouteSuggestionView/OriginTextField.swift
+++ b/BusRoad/Component/RouteSuggestionView/OriginTextField.swift
@@ -12,6 +12,7 @@ struct OriginTextField : View {
     @Binding var location: LocationInfo?
     @Binding var isSearchMode: Bool
     @Binding var locationType: LocationType
+    @Binding var userDidSelectOrigin: Bool
     
     var onRefreshTapped: () -> Void
     
@@ -19,7 +20,7 @@ struct OriginTextField : View {
             
             HStack(spacing: 12) {
                 Text("출발지")
-                    .foregroundColor(Color.greyNormal)
+                    .foregroundColor(Color.subPoint)
                     .font(.prereg20Scaled)
                 
                 Divider()
@@ -33,7 +34,7 @@ struct OriginTextField : View {
                   HStack{
                     Text(location?.name ?? "출발지를 입력하세요")
                       .font(.prereg20Scaled)
-                      .foregroundColor(Color.greyNormal)
+                      .foregroundColor(userDidSelectOrigin ? .greyHeavy : .greyNormal)
                     Spacer()
                   }
                 }

--- a/BusRoad/Feature/RouteSuggestion/RouteSuggestionView.swift
+++ b/BusRoad/Feature/RouteSuggestion/RouteSuggestionView.swift
@@ -90,6 +90,7 @@ struct RouteSuggestionView: View {
                                 location: $viewModel.origin,
                                 isSearchMode: $isSearchMode,
                                 locationType: $locationType,
+                                userDidSelectOrigin: $viewModel.userDidSelectOrigin,
                                 onRefreshTapped: {
                                     viewModel.userDidSelectOrigin = false
                                     viewModel.requestOrigin() }


### PR DESCRIPTION
## #️⃣ 관련 이슈
> closes #108

---

## 💻 작업 내용

> 출발지 컬러- subPoint, ’현위치’ 컬러- subNeutral, 사용자가 출발지를 직접 지정했을 때 컬러- greyHeavy가 되도록 반영했습니다.

---

## 📝 코드 설명

> OriginTextField에 userDidSelectOrigin 값을 넘겨서 컬러가 바뀌도록 했습니다.

---

## 🙋 리뷰 요구사항

> 코드 확인 부탁드려요:)

---
## ✋🏻 잠깐! 확인하셨나요?
- [x] 컨벤션 확인
- [x] 기능 정상 작동 테스트 완료
- [x] 디버깅 코드 및 주석 제거
- [x] 사용하지 않는 코드/파일 정리
- [x] 작업 내용 및 코드 설명 작성 

