### PR TITLE
Style/#112/텍스트검색 입력 중 결과 리스트 스타일 유지

### DIFF
--- a/BusRoad/Feature/MainSearch/SearchModeSection.swift
+++ b/BusRoad/Feature/MainSearch/SearchModeSection.swift
@@ -13,6 +13,8 @@ struct SearchModeSection: View {
     @Binding var hasSubmitted: Bool
     let isLoading: Bool
     
+    @State private var submittedQuery: String = ""
+    
     var body: some View {
         ZStack {
             Color.background
@@ -31,6 +33,11 @@ struct SearchModeSection: View {
                 }
             }
         }
+        .onChange(of: hasSubmitted) { _, newValue in
+                   if newValue {
+                       submittedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
+                   }
+               }
     }
     
     private var header: some View {
@@ -61,10 +68,6 @@ struct SearchModeSection: View {
         GeometryReader { geo in
             ScrollView {
                 VStack {
-                    
-                    // 디버깅용
-                    let _ = print("[SearchModeSection] hasSubmitted: \(hasSubmitted), isLoading: \(isLoading), results.count: \(results.count)")
-
                     // 검색 전 (제출 전)
                     if !hasSubmitted {
                         Spacer(minLength: 0)
@@ -104,7 +107,7 @@ struct SearchModeSection: View {
                                 PlaceCard(
                                     title: item.name,
                                     address: item.address,
-                                    searchQuery: query.trimmingCharacters(in: .whitespacesAndNewlines)
+                                    searchQuery: submittedQuery
                                 ) {
                                     // onTap
                                     onSelect(item)


### PR DESCRIPTION
## #️⃣ 관련 이슈
> closes #112

---

## 💻 작업 내용

> 사용자가 검색 후 검색창을 다시 수정하더라도 검색 결과의 하이라이트는 검색 시점의 검색어로 고정되어 유지되도록 했습니다!

---

## 📝 코드 설명

>
- SearchModeSection에 submittedQuery state를 추가하여 검색 제출 시점의 query를 저장하도록 했습니다.
- onChange(of: hasSubmitted)를 통해 검색 실행 시 submittedQuery를 업데이트하고, PlaceCard에는 submittedQuery를 전달하여 하이라이트가 고정되도록 했습니다.
---

## 🙋 리뷰 요구사항

> 코드 확인 부탁드립니당:) 

---
## ✋🏻 잠깐! 확인하셨나요?
- [x] 컨벤션 확인
- [x] 기능 정상 작동 테스트 완료
- [x] 디버깅 코드 및 주석 제거
- [x] 사용하지 않는 코드/파일 정리
- [x] 작업 내용 및 코드 설명 작성 

