### PR TITLE
[fix]#123 RouteCard 슬라이드 시 MarqueeText 애니메이션 멈춤 현상 해결

### DIFF
--- a/BusRoad/Component/Common/MarqueeText.swift
+++ b/BusRoad/Component/Common/MarqueeText.swift
@@ -6,6 +6,7 @@ public struct MarqueeText: View {
     public var uiFont: UIFont
     public var startDelay: Double
     public var alignment: Alignment
+    public var shouldAnimate: Bool = true
     
     @State private var animate = false
     var isCompact = false
@@ -41,7 +42,7 @@ public struct MarqueeText: View {
                 }
             }
             .onAppear {
-                if needsScrolling {
+                if needsScrolling && shouldAnimate {
                     DispatchQueue.main.asyncAfter(deadline: .now() + startDelay) {
                         self.animate = true
                     }
@@ -53,9 +54,18 @@ public struct MarqueeText: View {
                 
                 self.animate = false
                 
-                if newNeedsScrolling {
+                if newNeedsScrolling && shouldAnimate {
                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                         self.animate = true
+                    }
+                }
+            }
+            .onChange(of: shouldAnimate) { _, newValue in
+                animate = false
+                
+                if newValue && needsScrolling {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + startDelay) {
+                        animate = true
                     }
                 }
             }
@@ -68,13 +78,15 @@ public struct MarqueeText: View {
         font: Font,
         uiFont: UIFont,
         startDelay: Double = 1.0,
-        alignment: Alignment? = nil
+        alignment: Alignment? = nil,
+        shouldAnimate: Bool = true
     ) {
         self.text = text
         self.font = font
         self.uiFont = uiFont
         self.startDelay = startDelay
         self.alignment = alignment ?? .leading
+        self.shouldAnimate = shouldAnimate
     }
 }
 

--- a/BusRoad/Component/RouteSuggestionView/BoardingLocation.swift
+++ b/BusRoad/Component/RouteSuggestionView/BoardingLocation.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct BoardingLocation: View {
     var route: BusRouteNode
+    var isActive: Bool = true
     
     var body: some View {
         VStack(alignment: .leading, spacing: 24.wScaled){
@@ -23,7 +24,8 @@ struct BoardingLocation: View {
                     font: .presemi32Scaled,
                     uiFont: .presemi32Scaled,
                     startDelay: 1.0,
-                    alignment: .leading
+                    alignment: .leading,
+                    shouldAnimate: isActive
                 )
                 .foregroundColor(Color.subLight)
             }

--- a/BusRoad/Component/RouteSuggestionView/RouteCard.swift
+++ b/BusRoad/Component/RouteSuggestionView/RouteCard.swift
@@ -4,6 +4,7 @@ struct RouteCard: View {
     var allJourneys: [Journey]
     var journey: Journey
     var index: Int
+    var isActive: Bool = true
     
     var body: some View {
         
@@ -21,7 +22,7 @@ struct RouteCard: View {
                             
                             VStack(alignment: .leading, spacing: 36.wScaled) {
                               ETA(journeys: allJourneys, journey: journey, index: index)
-                                BoardingLocation(route: firstBusRoute)
+                                BoardingLocation(route: firstBusRoute, isActive: isActive)
                             }
                             
                             RouteSummary(journey: journey)

--- a/BusRoad/Component/RouteSuggestionView/RouteCardSlide.swift
+++ b/BusRoad/Component/RouteSuggestionView/RouteCardSlide.swift
@@ -15,7 +15,11 @@ struct RouteCardSlide: View {
                     ZStack {
                         ForEach(Array(routes.enumerated()), id: \.element.id) { index, item in
                             let relativeIndex: CGFloat = CGFloat(index - currentIndex)
-                            RouteCard(allJourneys: routes, journey: item, index: index)
+                            RouteCard(allJourneys: routes,
+                                      journey: item,
+                                      index: index,
+                                      isActive: currentIndex == index
+                            )
                                 .offset(x: relativeIndex * 270.wScaled)
                                 .scaleEffect(relativeIndex == 0 ? 1.0 : 0.9)
                                 .opacity(relativeIndex == 0 ? 1.0 : 0.3)


### PR DESCRIPTION
## #️⃣ 관련 이슈
> closes #123 

---

## 💻 작업 내용

> MarqueeText의 onApper가 뷰가 처음 생성될때만 실행되면서, 카드 슬라이드시 애니메이션이 재시작 되지 않았던 문제를 해결했습니다. 

---

## 📝 코드 설명

> 
**MarqueeText에 shoudAnimate 변수를 추가했습니다.**
- 외부에서 애니메이션 on/off 값을 제어할 수 있도록 했습니다.
- 기본값은 true로 만들어 두었습니다. 
- 기존 onChange에 shouldAnimation 조건을 추가하고, 새로운 onChange도 추가해서 값 변경시 애니메이션이 재생 되도록 했습니다. 

**RouteCard에 isActive 변수 추가**
- 현재 중앙에 있는 카드인지 여부를 전달받습니다. 
- BoardingLocation에 isActive를 전달합니다.

**BoardingLocation에서 MarqueeText에 'shouldAnimate' 전달**
- isActive의 값을 MarqueeText의 shouldAnimate로 전달합니다.
- 지금 보이는 카드만 애니메이션이 활성화 됩니다.

**RouteCardSlide에서 isActive를 전달합니다.**
- currentIndex == index로 현재 현재 보이는 카드를 판별합니다. 
- 보이는 카드만 isActive = ture 가 됩니다.

---

## 🙋 리뷰 요구사항

>  코드 확인 부탁드려요:)

---

## ✋🏻 잠깐! 확인하셨나요?
- [x] 컨벤션 확인
- [x] 기능 정상 작동 테스트 완료
- [x] 디버깅 코드 및 주석 제거
- [x] 사용하지 않는 코드/파일 정리
- [x] 작업 내용 및 코드 설명 작성 

