### PR TITLE
[feat] 승차 전 음성 알림 추가

### DIFF
--- a/BusRoad.xcodeproj/project.pbxproj
+++ b/BusRoad.xcodeproj/project.pbxproj
@@ -7,8 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		608B23A62EBD892D0005FCB5 /* Secrets.plist in Resources */ = {isa = PBXBuildFile; fileRef = 931B33E52EA5DB1600ED7944 /* Secrets.plist */; };
-		608B23A72EBD892D0005FCB5 /* Secrets.plist in Resources */ = {isa = PBXBuildFile; fileRef = 931B33E52EA5DB1600ED7944 /* Secrets.plist */; };
 		60A8CDB02E7CE7B900530B92 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 60A8CDAF2E7CE7A100530B92 /* .swiftlint.yml */; };
 		931B33E92EA5DB5D00ED7944 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 931B33E82EA5DB5D00ED7944 /* Lottie */; };
 		FEFDE9E22EB23C5200733205 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FEFDE9E12EB23C5200733205 /* WidgetKit.framework */; };
@@ -53,7 +51,6 @@
 		246B44332E823A2000E28F87 /* Exceptions for "BusRoad" folder in "BusRoad" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
-				Application/Secrets.plist,
 				Info.plist,
 			);
 			target = 60A8CDA02E7CDFE500530B92 /* BusRoad */;
@@ -77,6 +74,7 @@
 		FEFDED1F2EB305EB00733205 /* Exceptions for "BusRoad" folder in "ProgressWidgetExtension" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
+				Application/Secrets.plist,
 				Resource/Color.xcassets,
 				"Resource/Font/Paperlogy-5Medium.ttf",
 				"Resource/Font/Paperlogy-6SemiBold.ttf",
@@ -260,7 +258,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				60A8CDB02E7CE7B900530B92 /* .swiftlint.yml in Resources */,
-				608B23A62EBD892D0005FCB5 /* Secrets.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -268,7 +265,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				608B23A72EBD892D0005FCB5 /* Secrets.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BusRoad/Utility/Manager/ArrivalInfoManager.swift
+++ b/BusRoad/Utility/Manager/ArrivalInfoManager.swift
@@ -13,6 +13,7 @@ final class ArrivalInfoManager: ObservableObject {
     static let shared = ArrivalInfoManager()
     
     private let busArrivalService: BusArrivalService
+    private let voiceManager: VoiceAnnouncementManager
     
     private var refreshTask: Task<Void, Never>? = nil
     private var lastNearestRouteId: String? = nil
@@ -31,8 +32,11 @@ final class ArrivalInfoManager: ObservableObject {
     
     
     // Init
-    private init(busArrivalService: BusArrivalService? = nil) {
+    private init(busArrivalService: BusArrivalService? = nil,
+                 voiceManager: VoiceAnnouncementManager = VoiceAnnouncementManager.shared
+    ) {
         self.busArrivalService = busArrivalService ?? BusArrivalService()
+        self.voiceManager = voiceManager
     }
     
     
@@ -263,9 +267,14 @@ final class ArrivalInfoManager: ObservableObject {
     private func updateUI(with item: BusArrivalItem) {
         let minutes = item.arrtime / 60
         let text = minutes < 1 ? "곧 도착" : "\(minutes)분 후"
+        let wasArrivingSoon = isArrivingSoon
         
         isArrivingSoon = minutes < 2
         nearestBusInfo = (busNo: cleanBusNumber(item.routeno), arrivalText: text)
+        
+        if !wasArrivingSoon && isArrivingSoon {
+                voiceManager.announceBusArrival()
+        }
     }
     
     

--- a/BusRoad/Utility/Manager/VoiceAnnouncementManager.swift
+++ b/BusRoad/Utility/Manager/VoiceAnnouncementManager.swift
@@ -4,6 +4,8 @@ import Combine
 
 final class VoiceAnnouncementManager: NSObject, ObservableObject {
     
+    static let shared = VoiceAnnouncementManager()
+    
     private let synthesizer = AVSpeechSynthesizer()
     
     override init() {
@@ -46,6 +48,11 @@ final class VoiceAnnouncementManager: NSObject, ObservableObject {
     // 1정류장 남음
     func announceOneStation() {
         announce("이번 정류장에서 내려야해요.하차벨을 눌러주세요")
+    }
+    
+    // 승차 전, 곧 버스 도착 알림
+    func announceBusArrival() {
+        announce("곧 버스가 도착합니다.")
     }
 }
 


### PR DESCRIPTION
## #️⃣ 관련 이슈
> closes #203 

---

## 💻 작업 내용

> 승차 전 음성알림을 추가했습니다.

---

## 📝 코드 설명

> 기존에 있는 VoiceAnnoincementManager를 활용했습니다. 버스 도착 예정 시간 계산하는 함수에 추가했고, 기존에 곧 도착여부가 false였고, 처음으로 곧 도착여부가 true로 바뀌었을 때 동작하도록 해서 딱 1번만 호출되도록 구현했습니다.

---

## 🙋 리뷰 요구사항

> 리뷰어에게 특별히 봐줬으면 하는 부분을 적어주세요.

ex. 이 부분의 코드가 잘 작동하는지 체크해주실 수 있나요?

---

## 📁 참고한 내용 (선택)
* (주소 첨부)
* 
---

## ✋🏻 잠깐! 확인하셨나요?
- [ ] 컨벤션 확인
- [ ] 기능 정상 작동 테스트 완료
- [ ] 디버깅 코드 및 주석 제거
- [ ] 사용하지 않는 코드/파일 정리
- [ ] 작업 내용 및 코드 설명 작성 

