### PR TITLE
[Fix] 도보 3차 수정

### DIFF
--- a/BusRoad/Feature/Walking/DevRouteMapView.swift
+++ b/BusRoad/Feature/Walking/DevRouteMapView.swift
@@ -41,12 +41,6 @@ struct DevRouteMapView: View {
                 MapPolyline(coordinates: tmapCoordinates)
                     .stroke(routeColor, lineWidth: 5)
             }
-            
-            // 1-1) 경로의 모든 좌표에 작은 점 표시 (디버깅용!!)
-            ForEach(Array(tmapCoordinates.enumerated()), id: \.offset) { idx, coord in
-                MapCircle(center: coord, radius: 1.5)   // 반지름 1.5m 정도의 작은 점
-                    .foregroundStyle(.red.opacity(0.8))
-            }
 
             // 2) 목적지 (경로 없을 때)
             if let dest = destination, tmapCoordinates.isEmpty {


### PR DESCRIPTION
## #️⃣ 관련 이슈
> closes #213 

---

## 💻 작업 내용

- [x] 최종/중간 목적지 반경 조정(반대로)
- [x] 전체 경로가 도보 하나뿐일 경우, 0m가 되어도 도착판정 안되는 경우 해결
- [x] 도착판정이 이후에 조금만 멀어져도 다시 도보뷰로 돌아가는 문제 해결(manuallyArrived 이용)
- [x] 라이브액티비티 조건 제거
- [x] 재검색 조건 강화(엔드포인트와 현위치간 거리 임계값 이상 && 투영거리 임계값 이상)
- [x] coordinate 인덱스 뛰어넘을 경우 jump
- [x] 세그먼트(좌표와 좌표 사이 선분) 진행률에 따른 중간좌표 도착 판정(segmentRemain-> reachedSegmendEnd)

---

## 📝 코드 설명

- 재검색 조건 강화
: 이 코드는 예전 도보 1차 수정때 코드를 참조해 가져왔습니다. 다른 점은, 그때는 투영 거리만 조건이었다면 이제는 현위치와 좌표간 거리가 임계값 이상일 때를 AND 조건으로 참고하여 조건을 더 강화했다는 것입니다.
- coordinate 인덱스 뛰어넘을 경우 jump
: 이 또한 도보 1차 버그 수정때 코드 참조했습니다.
- isFinalNode라는 변수가 원래 있었는데, 사실은 isLastJourney라고 이름지어야 할 만한 변수였으며 쓸 데도 없었다는 것을 발견해 isLastRouteSegment라는 변수를 새로 만들어 이후 여러 코드에 대한 조건을 재탐색하고 수정했습니다.
- arrived 변수 조건 변경
: 원래 arrived 판정이 말도 안된다는(isFinalNode 관련 문제..) 것을 깨달아서, 현재는 `arrived = reachedFinalDestination || (remain < finalArrivalStraightDistance)`로 바꾸었습니다 -> 티맵 경로의 맨끝지점이 최종목적지와 다를 수도 있다는 점을 고려하여, reachedFinalDestination(현위치가 최종목적지 좌표와 가까운가) OR 경로상 남은 거리가 기준치 이하(정류장일 경우 12m, 최종목적지일 경우 6m)인가로 조정했습니다.

---

## 🙋 리뷰 요구사항

> 변수값(임계값 등)을 테스트를 하면서 조정해야 할 것 같긴 합니다. GPS 때문에 가끔 방향이 불안정하긴 하지만 치명적인 오류는 없어 보입니다. 만약 치명적인 오류가 있다면 피드백 부탁드립니다..

---

## 📁 참고한 내용 (선택)
* (주소 첨부)
* 
---

## ✋🏻 잠깐! 확인하셨나요?
- [x] 컨벤션 확인
- [x] 기능 정상 작동 테스트 완료
- [x] 디버깅 코드 및 주석 제거
- [x] 사용하지 않는 코드/파일 정리
- [x] 작업 내용 및 코드 설명 작성 

