### PR TITLE
[feat]#127 음성검색뷰 풀스크린으로 변경

### DIFF
--- a/BusRoad/Feature/MainSearch/MainSearchView.swift
+++ b/BusRoad/Feature/MainSearch/MainSearchView.swift
@@ -32,7 +32,6 @@ struct MainSearchView: View {
                     onMicTap: {
                         viewModel.handleMicTap()
                         isFocused = false
-                        coordinator.push(.voiceSearch)
                     },
                     onSelect: { item in
                         viewModel.selectPlace(item: item)
@@ -53,7 +52,6 @@ struct MainSearchView: View {
                     onMicTap: {
                         viewModel.handleMicTap()
                         isFocused = false
-                        coordinator.push(.voiceSearch)
                     },
                     onClear: {
                         viewModel.clearQuery()

--- a/BusRoad/Feature/MainSearch/MainSearchViewModel.swift
+++ b/BusRoad/Feature/MainSearch/MainSearchViewModel.swift
@@ -28,9 +28,9 @@ final class MainSearchViewModel: ObservableObject {
     var isLoading: Bool { searchManager.isLoading }
     var errorMessage: String? { searchManager.errorMessage }
     
-    
     init() {
         self.hasShownVoiceHint = UserDefaults.standard.bool(forKey: kHasShownVoiceHint)
+        
         searchManager.$hasSubmitted
             .assign(to: &$hasSubmitted)
         
@@ -39,8 +39,13 @@ final class MainSearchViewModel: ObservableObject {
             .store(in: &bag)
     }
     
-    func search() async { await searchManager.search() }
-    func resetSearchMode() { searchManager.resetSearchMode() }
+    func search() async {
+        await searchManager.search()
+    }
+    
+    func resetSearchMode() {
+        searchManager.resetSearchMode()
+    }
     
     func setDestination(destination: LocationInfo) {
         journeyManager.setDestination(destination)
@@ -48,6 +53,10 @@ final class MainSearchViewModel: ObservableObject {
     
     func resetManager() {
         searchManager.reset()
+    }
+    
+    func warmUpLocation() {
+        journeyManager.warmUpLocation()
     }
     
     // MARK: - 액션 메서드들
@@ -71,9 +80,28 @@ final class MainSearchViewModel: ObservableObject {
         query = ""
     }
     
-    /// 마이크 버튼 탭
+    /// 마이크 버튼 탭 → 풀스크린 뷰 열기
     func handleMicTap() {
         showHint = false
+        VoiceSearchManager.shared.present { [weak self] text in
+            self?.handleVoiceSearchCompleted(text)
+        }
+    }
+    
+    /// 음성 검색 완료 → 쿼리 반영 + 검색 실행
+    func handleVoiceSearchCompleted(_ text: String) {
+        showHint = false
+        query = text
+        isSearchMode = true
+        
+        Task { [weak self] in
+            await self?.search()
+        }
+    }
+    
+    /// 음성 검색 뷰에서 닫기
+    func dismissVoiceSearch() {
+        VoiceSearchManager.shared.dismiss()
     }
     
     /// 장소 선택
@@ -85,9 +113,5 @@ final class MainSearchViewModel: ObservableObject {
         ))
         resetManager()
         isSearchMode = false
-    }
-    
-    func warmUpLocation() {
-        journeyManager.warmUpLocation()
     }
 }

--- a/BusRoad/Feature/RouteSuggestion/BusRouteViewModel.swift
+++ b/BusRoad/Feature/RouteSuggestion/BusRouteViewModel.swift
@@ -365,3 +365,27 @@ extension BusRouteViewModel {
         return result.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }
+
+// MARK: - 음성 검색 관련 메서드들
+extension BusRouteViewModel {
+    /// 마이크 버튼 탭 → 풀스크린 뷰 열기
+    func handleMicTap() {
+        VoiceSearchManager.shared.present { [weak self] text in
+            self?.handleVoiceSearchCompleted(text)
+        }
+    }
+    
+    /// 음성 검색 완료 → 쿼리 반영 + 검색 실행
+    func handleVoiceSearchCompleted(_ text: String) {
+        query = text
+        isSearchMode = true
+        Task {
+            await search()
+        }
+    }
+    
+    /// 음성 검색 뷰에서 닫기
+    func dismissVoiceSearch() {
+        VoiceSearchManager.shared.dismiss()
+    }
+}

--- a/BusRoad/Feature/RouteSuggestion/RouteSuggestionView.swift
+++ b/BusRoad/Feature/RouteSuggestion/RouteSuggestionView.swift
@@ -28,7 +28,7 @@ struct RouteSuggestionView: View {
                 },
                 onMicTap: {
                     isFocused = false
-                    coordinator.push(.voiceSearch)
+                    viewModel.handleMicTap()
                 },
                 onSelect: { item in
                     viewModel.selectPlace(item: item, locationType: viewModel.locationType)

--- a/BusRoad/Feature/VoiceSearch/VoiceSearchView.swift
+++ b/BusRoad/Feature/VoiceSearch/VoiceSearchView.swift
@@ -1,7 +1,10 @@
 import SwiftUI
 
 struct VoiceSearchView: View {
-    @EnvironmentObject private var coordinator: NavigationCoordinator
+    
+    let onCompleted: (String) -> Void
+    let onDismiss: () -> Void
+    
     @StateObject var viewModel = VoiceSearchViewModel()
     
     
@@ -61,14 +64,17 @@ struct VoiceSearchView: View {
         }
         .toolbar(.hidden, for: .navigationBar)
         .onAppear {
-            // 1) 완료 시: 외부 콜백(있으면) -> pop
+           // 음성 인식 완료 시
             viewModel.onSearchCompleted = { text in
-                coordinator.pop()
+                onCompleted(text)
             }
             
-            // 2) 닫기(X) 시 pop
-            viewModel.onDismiss = { coordinator.pop() }
-            // 3) 실제 리스닝 시작/바인딩
+          // 닫기
+            viewModel.onDismiss = {
+                onDismiss()
+            }
+            
+            // 실제 리스닝 시작/바인딩
             viewModel.onAppear()
         }
         .onDisappear {

--- a/BusRoad/Navigation/AppNavigationView.swift
+++ b/BusRoad/Navigation/AppNavigationView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct AppNavigationView: View {
     @EnvironmentObject var coordinator: NavigationCoordinator
+    @StateObject private var voiceSearchManager = VoiceSearchManager.shared
     
     var body: some View {
         NavigationStack(path: $coordinator.path) {
@@ -22,14 +23,22 @@ struct AppNavigationView: View {
                     case .mainSearch:
                         MainSearchView()
                             .toolbar(.hidden, for: .navigationBar)
-                    case .voiceSearch:
-                        VoiceSearchView()
-                            .toolbar(.hidden, for: .navigationBar)
                     case .journeyFlow:
                         JourneyFlowView()
                             .toolbar(.hidden, for: .navigationBar)
                     }
                 }
+        }
+        .fullScreenCover(isPresented: $voiceSearchManager.isPresented) {
+            VoiceSearchView(
+                onCompleted: { text in
+                    voiceSearchManager.onCompleted?(text)
+                    voiceSearchManager.dismiss()
+                },
+                onDismiss: {
+                    voiceSearchManager.dismiss()
+                }
+            )
         }
     }
 }

--- a/BusRoad/Navigation/Route.swift
+++ b/BusRoad/Navigation/Route.swift
@@ -10,7 +10,6 @@ import SwiftUI
 
 enum Route: Hashable {
     case mainSearch
-    case voiceSearch
     case routeSuggestion
     case journeyFlow
 }

--- a/BusRoad/Utility/Manager/VoiceSearchManager.swift
+++ b/BusRoad/Utility/Manager/VoiceSearchManager.swift
@@ -1,0 +1,21 @@
+import Combine
+
+@MainActor
+class VoiceSearchManager: ObservableObject {
+    static let shared = VoiceSearchManager()
+    
+    @Published var isPresented: Bool = false
+    var onCompleted: ((String) -> Void)?
+    
+    private init() {}
+    
+    func present(onCompleted: @escaping (String) -> Void) {
+        self.onCompleted = onCompleted
+        self.isPresented = true
+    }
+    
+    func dismiss() {
+        self.isPresented = false
+        self.onCompleted = nil
+    }
+}


### PR DESCRIPTION
## #️⃣ 관련 이슈
> closes #217 

---

## 💻 작업 내용

> vioceSearchView를 풀스크린커버로 변경했습니다.

---

## 📝 코드 설명

> 각 뷰에서 풀스크린을 띄우려고 했으나, RouteSuggestionView가 네비게이션으로 관리되면서, 음성검색시 검색화면 뒤쪽에 풀스크린이 생기는 상황이 발생했습니다. 그래서 최상단에서 관리할수 있도록 VoiceSearchManager를 만들어서 하나로 관리하도록 했습니다.
---

## 🙋 리뷰 요구사항

> 브랜치 번호를 잘못봤어요.. 127이 아니라 217번 입니다..ㅎㅎ;;

---

## ✋🏻 잠깐! 확인하셨나요?
- [x] 컨벤션 확인
- [x] 기능 정상 작동 테스트 완료
- [x] 디버깅 코드 및 주석 제거
- [x] 사용하지 않는 코드/파일 정리
- [x] 작업 내용 및 코드 설명 작성 

