### PR TITLE
[feat]#210 정류장 간 균등하게 계산하기

### DIFF
--- a/BusRoad/Component/OnRideView/OnRideCard.swift
+++ b/BusRoad/Component/OnRideView/OnRideCard.swift
@@ -93,7 +93,7 @@ struct OnRideCard: View {
                 .padding(.leading, canAlight ? 30.wScaled : -20.wScaled)
         }
         )
-      
+        
     }
     
 }
@@ -105,12 +105,13 @@ struct BusStopProgress: View {
     let progress: CGFloat
     var trackColor: Color = .subNormal
     var fillColor: Color = .subHeavy
+    @State private var animatedProgress: CGFloat = 0
     
     var body: some View {
         
         GeometryReader { geometry in
             let width = geometry.size.width
-            let progress = min(max(progress, 0), 1)
+            let clampedProgress = min(max(animatedProgress, 0), 1)
             
             ZStack(alignment: .leading) {
                 Rectangle()
@@ -119,21 +120,29 @@ struct BusStopProgress: View {
                     .foregroundStyle(trackColor)
                 
                 Rectangle()
-                    .frame(width: progress*width, height: 8)
+                    .frame(width: clampedProgress * width, height: 8) 
                     .foregroundStyle(fillColor)
                     .clipShape(
                         UnevenRoundedRectangle(
                             cornerRadii: .init(
                                 topLeading: 10,
                                 bottomLeading: 10,
-                                bottomTrailing: progress >= 1 ? 10 : 0,
-                                topTrailing: progress >= 1 ? 10 : 0
+                                bottomTrailing: clampedProgress >= 1 ? 10 : 0,  // 👈 여기도
+                                topTrailing: clampedProgress >= 1 ? 10 : 0  // 👈 여기도
                             )
                         )
                     )
             }
         }
         .frame(height: 8)
+        .onChange(of: progress) { oldValue, newValue in
+            withAnimation(.easeInOut(duration: 0.5)) {
+                animatedProgress = newValue
+            }
+        }
+        .onAppear {
+            animatedProgress = progress
+        }
     }
 }
 

--- a/BusRoad/Utility/Manager/AlightProximityManager.swift
+++ b/BusRoad/Utility/Manager/AlightProximityManager.swift
@@ -34,10 +34,6 @@ final class AlightProximityManager: ObservableObject {
     // 건너뛰기 감지
     private var missedStationsCheck: Set<Int> = []
     
-    // 정류장 간 거리 및 진행률
-    private var segmentDistances: [CLLocationDistance] = []
-    private var totalDistance: CLLocationDistance = 0
-    
     // TAGO 연동
     private var cityCode: Int?
     private var routeId: String?
@@ -80,9 +76,6 @@ final class AlightProximityManager: ObservableObject {
             return
         }
         
-        // 정류장 간 거리 사전 계산
-        calculateSegmentDistances()
-        
         currentStationIndex = 1  // 첫 정류장(탑승)은 이미 지남
         remainingStations = max(0, stations.count - currentStationIndex)
         hasArrived = false
@@ -100,22 +93,6 @@ final class AlightProximityManager: ObservableObject {
         print("[AlightProximityManager] 구성 완료 / 정류장: \(stations.count), 다음 index: \(currentStationIndex), 남은: \(remainingStations)")
         
         ProgressLiveActivityManager.shared.updateRemainingBusStops(remaining: remainingStations)
-    }
-    
-    // 정류장 간 거리 계산
-    private func calculateSegmentDistances() {
-        segmentDistances.removeAll()
-        totalDistance = 0
-        
-        for i in 0..<(stations.count - 1) {
-            let from = CLLocation(latitude: stations[i].latitude, longitude: stations[i].longitude)
-            let to = CLLocation(latitude: stations[i+1].latitude, longitude: stations[i+1].longitude)
-            let dist = from.distance(from: to)
-            segmentDistances.append(dist)
-            totalDistance += dist
-        }
-        
-        print("[AlightProximityManager] 총 거리: \(Int(totalDistance))m, 구간: \(segmentDistances.count)개")
     }
     
     func setTagoContext(cityCode: Int, routeId: String, vehicleNo: String?) {
@@ -231,15 +208,15 @@ final class AlightProximityManager: ObservableObject {
             let wasInside = stationProximityState[idx] ?? false
             let isInside = distance <= confirmRadius
             
+            // 마지막 정류장 진입 시 100%
             if idx == stations.count - 1 && isInside && !wasInside {
-                       // 마지막 정류장에 처음 진입!
-                       print("[AlightProximityManager] 🎉 마지막 정류장 진입 - Progress 100%")
-                       progress = 1.0
-                       hasArrived = true
-                       Task {
-                           ProgressLiveActivityManager.shared.updateBusProgress(busProgress: 1.0)
-                       }
-                   }
+                print("[AlightProximityManager] 🎉 마지막 정류장 진입 - Progress 100%")
+                progress = 1.0
+                hasArrived = true
+                Task {
+                    ProgressLiveActivityManager.shared.updateBusProgress(busProgress: 1.0)
+                }
+            }
             
             if isInside && !wasInside {
                 // 진입
@@ -279,8 +256,6 @@ final class AlightProximityManager: ObservableObject {
     private func handleStationPassed(index: Int, station: BusStation, reason: String) {
         guard index == currentStationIndex else { return }
         
-        let isLast = (index == stations.count - 1)
-        
         print("[AlightProximityManager] ✅ 통과: [\(index)] \(station.stationName) (\(reason))")
         
         currentStationIndex = index + 1
@@ -288,34 +263,11 @@ final class AlightProximityManager: ObservableObject {
         lastStationPassedTime = Date()
         missedStationsCheck.remove(index)
         
-        // progress 업데이트 (마지막 정류장이 아닐 때만)
-        if !isLast && totalDistance > 0, segmentDistances.count >= stations.count - 1 {
-            var passedDistance: CLLocationDistance = 0
-           
-            for i in 0..<currentStationIndex {
-                if i < segmentDistances.count {
-                    passedDistance += segmentDistances[i]
-                }
-            }
-            
-            let newProgress = min(1.0, max(0, passedDistance / totalDistance))
-            progress = CGFloat(newProgress)
-            
-            Task {
-                ProgressLiveActivityManager.shared.updateBusProgress(busProgress: newProgress)
-            }
-            print("[AlightProximityManager] Progress 업데이트: \(String(format: "%.1f%%", newProgress * 100))")
-        }
-        
         Task {
             ProgressLiveActivityManager.shared.updateRemainingBusStops(remaining: self.remainingStations)
         }
         
         print("[AlightProximityManager] 남은 정류장: \(remainingStations)")
-        
-        if isLast {
-            print("[AlightProximityManager] 🎉 목적지 통과 완료!")
-        }
         
         if remainingStations <= 1 {
             canAlight = true
@@ -334,23 +286,22 @@ final class AlightProximityManager: ObservableObject {
         onStationPassed?(index, station.stationName)
     }
     
-    // MARK: - 진행률 계산 (정류장 간 거리 기반)
+    // MARK: - 진행률 계산 (정류장 간격 균등 분할)
     
     private func updateDetailedProgress(currentLocation: CLLocation) {
-        guard stations.count >= 2, currentStationIndex > 0 else {
+        guard stations.count >= 2, currentStationIndex > 0, currentStationIndex <= stations.count else {
             progress = 0
             return
         }
         
-        // 이미 통과한 구간 거리 합
-        var passedDistance: CLLocationDistance = 0
-        for i in 0..<(currentStationIndex - 1) {
-            if i < segmentDistances.count {
-                passedDistance += segmentDistances[i]
-            }
-        }
+        let totalStops = stations.count - 1  // 전체 구간 수
         
-        // 현재 구간 진행률
+        // 이미 통과한 정류장 수
+        let completedStops = currentStationIndex - 1
+        
+        // 현재 구간 진행률 계산 (0.0 ~ 1.0)
+        var currentSegmentProgress: Double = 0.0
+        
         if currentStationIndex < stations.count {
             let prevStation = stations[currentStationIndex - 1]
             let nextStation = stations[currentStationIndex]
@@ -360,15 +311,16 @@ final class AlightProximityManager: ObservableObject {
             
             let segmentLength = prevLoc.distance(from: nextLoc)
             let distanceToNext = currentLocation.distance(from: nextLoc)
-            let currentSegmentProgress = max(0, segmentLength - distanceToNext)
+            let progressInSegment = max(0, min(1.0, (segmentLength - distanceToNext) / segmentLength))
             
-            passedDistance += currentSegmentProgress
+            currentSegmentProgress = progressInSegment
         }
         
-        // 전체 진행률
-        let newProgress = min(1.0, max(0, passedDistance / totalDistance))
+        // 전체 진행률 = (통과한 구간 + 현재 구간 진행률) / 전체 구간
+        let totalProgress = (Double(completedStops) + currentSegmentProgress) / Double(totalStops)
+        let newProgress = min(1.0, max(0, totalProgress))
         
-        if newProgress > progress {
+        if newProgress > Double(progress) {
             progress = CGFloat(newProgress)
             Task {
                 ProgressLiveActivityManager.shared.updateBusProgress(busProgress: newProgress)
@@ -498,8 +450,6 @@ final class AlightProximityManager: ObservableObject {
         lastStationPassedTime = nil
         
         missedStationsCheck.removeAll()
-        segmentDistances.removeAll()
-        totalDistance = 0
         stationProximityState.removeAll()
     }
     


### PR DESCRIPTION
## #️⃣ 관련 이슈
> closes #210 

---

## 💻 작업 내용

> 정류장 Progress 로직 수정 및 애니메이션 추가

---

## 📝 코드 설명

> 정류장을 지났다고 감지하는경우 갑자기 progress가 늘어나는 기이한(?) 현상과, 여전히 고쳐지지 않은 마지막정류장 progress문제가 있었습니다. 원인을 찾고 보니 제가 정류장간의 거리로 한다는 것이 정류장간 실제거리를 기반으로 만들어서 그런 오류가 생긴것같아요.
정류장간 거리를 균등하게 계산하고 움직이도록 수정했습니다. 그리고 마지막 정류장에서도 바로 100%되지 않도록 조정해두었습니다:) 프로그레스 애니메이션도 추가되었습니다!

---

## 🙋 리뷰 요구사항

> gpx 파일로 테스트했습니다. 실제 테스트는 내일 하는 것으로..

---

## ✋🏻 잠깐! 확인하셨나요?
- [ ] 컨벤션 확인
- [ ] 기능 정상 작동 테스트 완료
- [ ] 디버깅 코드 및 주석 제거
- [ ] 사용하지 않는 코드/파일 정리
- [ ] 작업 내용 및 코드 설명 작성 

