### PR TITLE
[fix] 키보드 내리기, 중복 제거

### DIFF
--- a/BusRoad.xcodeproj/project.pbxproj
+++ b/BusRoad.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		248374D72ECD66B30005F935 /* Secrets.plist in Resources */ = {isa = PBXBuildFile; fileRef = 931B33E52EA5DB1600ED7944 /* Secrets.plist */; };
 		603D50272ECAB88C00476C7F /* Secrets.plist in Resources */ = {isa = PBXBuildFile; fileRef = 931B33E52EA5DB1600ED7944 /* Secrets.plist */; };
 		60A8CDB02E7CE7B900530B92 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 60A8CDAF2E7CE7A100530B92 /* .swiftlint.yml */; };
 		931B33E92EA5DB5D00ED7944 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 931B33E82EA5DB5D00ED7944 /* Lottie */; };
@@ -258,6 +259,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				60A8CDB02E7CE7B900530B92 /* .swiftlint.yml in Resources */,
+				248374D72ECD66B30005F935 /* Secrets.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BusRoad/Feature/MainSearch/SubView/SearchModeSection.swift
+++ b/BusRoad/Feature/MainSearch/SubView/SearchModeSection.swift
@@ -18,6 +18,7 @@ struct SearchModeSection: View {
     
     @State private var submittedQuery: String = ""
     @State private var selectedItem: PlaceSummary?
+    @State private var isSelected: Bool = false
     
     @ObservedObject var store: LocationStore
     
@@ -33,7 +34,7 @@ struct SearchModeSection: View {
         }
         .ignoresSafeArea(.keyboard)
         .onAppear {
-            if results.isEmpty && query.isEmpty {
+            if results.isEmpty && query.isEmpty && !isSelected {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                     isFocused.wrappedValue = true
                 }
@@ -95,7 +96,10 @@ struct SearchModeSection: View {
                                 ForEach(store.locations) { item in
                                     RecentCard(
                                         title: item.name,
-                                        onSelect: { onSelect(item) },
+                                        onSelect: {
+                                            isSelected = true
+                                            onSelect(item)
+                                        },
                                         onDelete: { onDelete(item) }
                                     )
                                 }

--- a/BusRoad/Utility/Store/LocationStore.swift
+++ b/BusRoad/Utility/Store/LocationStore.swift
@@ -20,14 +20,16 @@ class LocationStore: ObservableObject {
     
     /// 최대 10개까지 추가
     func add(_ location: PlaceSummary) {
-        // 중복은 제거 (옵션)
-        if let index = locations.firstIndex(of: location) {
+        // 이름 기준으로 중복 판단
+        if let index = locations.firstIndex(where: {
+            $0.name == location.name
+        }) {
             locations.remove(at: index)
             print("[DEBUG] 최근검색어: 중복 제거")
         }
-        
-        locations.insert(location, at: 0)   // 최근이 앞으로 오도록
-        
+
+        locations.insert(location, at: 0)
+
         if locations.count > 10 {
             locations = Array(locations.prefix(10))
         }


### PR DESCRIPTION
## #️⃣ 관련 이슈
> closes #251 

---

## 💻 작업 내용

> 최근검색어 시 키보드 내리기 + 중복 제거

---

## 📝 코드 설명

> 최근검색어 클릭 시 isSelected = true가 되면서 나중에 키보드가 올라오지 않도록 수정함. + 최근검색어 추가 시 이름으로 동일성 판단해서 중복 제거

---

## 🙋 리뷰 요구사항

> 리뷰어에게 특별히 봐줬으면 하는 부분을 적어주세요.

ex. 이 부분의 코드가 잘 작동하는지 체크해주실 수 있나요?

---

## 📁 참고한 내용 (선택)
* (주소 첨부)
* 
---

## ✋🏻 잠깐! 확인하셨나요?
- [ ] 컨벤션 확인
- [ ] 기능 정상 작동 테스트 완료
- [ ] 디버깅 코드 및 주석 제거
- [ ] 사용하지 않는 코드/파일 정리
- [ ] 작업 내용 및 코드 설명 작성 

