### PR TITLE
[fix] 지도맵 버튼 높이 조절

### DIFF
--- a/BusRoad/Component/RouteSuggestionView/RouteSelectButton.swift
+++ b/BusRoad/Component/RouteSuggestionView/RouteSelectButton.swift
@@ -128,7 +128,7 @@ struct RouteSelectButton: View {
                 Text("새로고침 하기")
                     .foregroundColor(Color.subLight)
                     .font(.premed32)
-                    .frame(width: 305.wScaled, height: 64)
+                    .frame(width: 305.wScaled, height: 64.wScaled)
                     .background(Color.subPoint)
                     .cornerRadius(20)
             }

--- a/BusRoad/Feature/MainSearch/SubView/LocationMap.swift
+++ b/BusRoad/Feature/MainSearch/SubView/LocationMap.swift
@@ -73,8 +73,8 @@ struct LocationMap: View {
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.horizontal, 30.wScaled)
-                    .padding(.bottom, 25.wScaled)
                     .padding(.top, 30.wScaled)
+                    Spacer()
                     Button(action: {
                         onSelect()
                         isPresented = false
@@ -83,15 +83,17 @@ struct LocationMap: View {
                             .font(.premed28Scaled)
                             .foregroundColor(.subLight)
                             .padding(.horizontal, 96.wScaled)
-                            .padding(.vertical, 13.5.wScaled)
+                            .frame(height: 64.wScaled)
                             .background(
                                 RoundedRectangle(cornerRadius: 20)
                                     .foregroundColor(Color.subPoint)
                             )
                             .cornerRadius(10)
                     }
+                    .padding(.bottom, 34.wScaled)
                     .padding(.horizontal)
                 }
+                .ignoresSafeArea()
                 .frame(height: 205.wScaled)
                 .background(
                     Rectangle()


### PR DESCRIPTION
## #️⃣ 관련 이슈
> closes #256 

---

## 💻 작업 내용

> 지도맵 버튼 아래의 패딩값을 줘서 경로추천뷰의 버튼과 높이가 같아지도록 수정했습니다. 조절하며 버튼 자체의 세로폭도 함께 조절했습니다.

---

## 📝 코드 설명

> 구현하면서 고려한 점, 구조를 이렇게 구성한 이유 등을 간단히 적어주세요. 

ex. ViewModel에서 선택 흐름 추적을 위해 path를 배열로 관리했습니다.

---

## 🙋 리뷰 요구사항

> 리뷰어에게 특별히 봐줬으면 하는 부분을 적어주세요.

ex. 이 부분의 코드가 잘 작동하는지 체크해주실 수 있나요?

---

## 📁 참고한 내용 (선택)
* (주소 첨부)
* 
---

## ✋🏻 잠깐! 확인하셨나요?
- [ ] 컨벤션 확인
- [ ] 기능 정상 작동 테스트 완료
- [ ] 디버깅 코드 및 주석 제거
- [ ] 사용하지 않는 코드/파일 정리
- [ ] 작업 내용 및 코드 설명 작성 

