### PR TITLE
Style/#260/onboarding view

### DIFF
--- a/BusRoad/Feature/Walking/WalkingView.swift
+++ b/BusRoad/Feature/Walking/WalkingView.swift
@@ -169,6 +169,7 @@ struct WalkingView: View {
                 Color.black.opacity(0.25).ignoresSafeArea()
                 VStack(spacing: 12) {
                     ProgressView()
+                        .tint(.primarywhite)
                     Text("경로 재탐색 중…")
                         .font(.callout)
                         .foregroundColor(.white)


### PR DESCRIPTION
## #️⃣ 관련 이슈
> closes #260

---

## 💻 작업 내용

> 도보 온보딩 화면에서 화면이 늘어나던 문제와, 재탐색 progress view 색상을 변경했습니다.

---

## 📝 코드 설명

>  기존 Z스택 안에 들어가있던 도보 온보딩화면을 오버레이로 변경했습니다. 
> 재탐색 Progress View의 색상을 흰색으로 변경했습니다.

---

## 🙋 리뷰 요구사항

> 리뷰어에게 특별히 봐줬으면 하는 부분을 적어주세요.

ex. 이 부분의 코드가 잘 작동하는지 체크해주실 수 있나요?

---

## ✋🏻 잠깐! 확인하셨나요?
- [x] 컨벤션 확인
- [x] 기능 정상 작동 테스트 완료
- [x] 디버깅 코드 및 주석 제거
- [x] 사용하지 않는 코드/파일 정리
- [x] 작업 내용 및 코드 설명 작성 

