### PR TITLE
[fix] #263 경로추천 오류 버튼 수정

### DIFF
--- a/BusRoad/Component/RouteSuggestionView/RouteSelectButton.swift
+++ b/BusRoad/Component/RouteSuggestionView/RouteSelectButton.swift
@@ -108,7 +108,7 @@ struct RouteSelectButton: View {
             Button {
                 retrySearch()
             } label: {
-                Text("처음으로")
+                Text("다시 검색하기")
                     .foregroundColor(Color.subLight)
                     .font(.premed32)
                     .frame(width: 305.wScaled, height: 64)


### PR DESCRIPTION

## #️⃣ 관련 이슈
> closes #263 

---

## 💻 작업 내용

> 출발지 =도착지 일때 하단 버튼 명 "처음으로" -> "다시 검색하기"로 수정

기존 레이블 "처음으로" -> 다시 검색하기
로 수정했습니다.


---

## 📝 코드 설명

> 구현하면서 고려한 점, 구조를 이렇게 구성한 이유 등을 간단히 적어주세요. 

ex. ViewModel에서 선택 흐름 추적을 위해 path를 배열로 관리했습니다.

---

## 🙋 리뷰 요구사항

> 리뷰어에게 특별히 봐줬으면 하는 부분을 적어주세요.

ex. 이 부분의 코드가 잘 작동하는지 체크해주실 수 있나요?

---

## 📁 참고한 내용 (선택)
* (주소 첨부)
* 
---

## ✋🏻 잠깐! 확인하셨나요?
- [ ] 컨벤션 확인
- [ ] 기능 정상 작동 테스트 완료
- [ ] 디버깅 코드 및 주석 제거
- [ ] 사용하지 않는 코드/파일 정리
- [ ] 작업 내용 및 코드 설명 작성 

