### PR TITLE
Feat/#278/도보 방향 즉시 변환

### DIFF
--- a/BusRoad/Feature/Walking/WalkingViewModel.swift
+++ b/BusRoad/Feature/Walking/WalkingViewModel.swift
@@ -37,7 +37,7 @@ final class WalkingViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
     var tmapTotalDistance: Int = 0
     
     // 거리 임계값
-    private let stepSwitchDistance: CLLocationDistance = 15
+    private let stepSwitchDistance: CLLocationDistance = 3 // 다음 좌표까지 ?m 이내이면 해당 점을 "지나간 것으로 판단"
     private var arrivalDistance: CLLocationDistance = 12
     private let offRouteThreshold: CLLocationDistance = 50
     


### PR DESCRIPTION
## #️⃣ 관련 이슈
> closes #278 

---

## 💻 작업 내용

- [ ] 좌/우회전 음성 안내 제거
- [ ] 다음 세그먼트로 전환하는 좌표 접근 임계값 - 15m -> 3m

---

## 📝 코드 설명

> 좌/우회전 음성 안내 관련 코드 전부 제거했습니다.

stepSwitchDistance = 15 -> 3 로 조정했을 때, 서울 골목에서 테스트할 때는 괜찮았습니다.

---

## 🙋 리뷰 요구사항

> 서울 좁고 복잡한 골목에서도 물론 테스트해야 하지만, 폭이 넓은 인도에서도 테스트해봐야 할 것 같습니다.
폭이 넓어서 만약 3m 안에 못 들어가서 화살표가 뒤쪽을 가리키는 경우도 존재할 수도 있어서요!!

---

## 📁 참고한 내용 (선택)
* (주소 첨부)
* 
---

## ✋🏻 잠깐! 확인하셨나요?
- [ ] 컨벤션 확인
- [ ] 기능 정상 작동 테스트 완료
- [ ] 디버깅 코드 및 주석 제거
- [ ] 사용하지 않는 코드/파일 정리
- [ ] 작업 내용 및 코드 설명 작성 

