### PR TITLE
[feat] 영어설정 시 라액 영어정류장명 전달

### DIFF
--- a/BusRoad/Component/RouteSuggestionView/RouteSelectButton.swift
+++ b/BusRoad/Component/RouteSuggestionView/RouteSelectButton.swift
@@ -14,6 +14,8 @@ struct RouteSelectButton: View {
     var routes: [Journey]?
     var onSelect: () -> Void
     var retrySearch: () -> Void
+
+    private let languageCode = Locale.current.language.languageCode?.identifier
     
     var body: some View {
         if viewModel.errorMessage == nil {
@@ -27,18 +29,20 @@ struct RouteSelectButton: View {
                             switch firstNode {
                             case .walk(let walkNode):
                                 // 수정: walkNode.end.name은 승차 정류장 이름
+                                let destination = self.languageCode == "ko" ? walkNode.end.name : walkNode.end.englishName ?? walkNode.end.name
                                 DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
                                     ProgressLiveActivityManager.shared.startActivity(
                                         totalDistance: Double(WalkingViewModel().tmapTotalDistance),
                                         stage: RouteStage.walkingToBus.rawValue,
-                                        destination: walkNode.end.name,  // 승차 정류장 이름
+                                        destination: destination,  // 승차 정류장 이름
                                         remainingBusStops: 0,
                                         timeTillBusArrival: 0
                                     )
                                 }
-                                print("[DEBUG] Live Activity 시작 - walkingToBus, destination: \(walkNode.end.name)")
+                                print("[DEBUG] Live Activity 시작 - walkingToBus, destination: \(destination)")
                             case .bus(let busNode):
-                                let destinationName = selectedJourney.busSegments.first?.end.name ?? "목적지"
+                                let busSegmentEnd = selectedJourney.busSegments.first?.end
+                                let destinationName = self.languageCode == "ko" ? (busSegmentEnd?.name ?? "목적지") : (busSegmentEnd?.englishName ?? busSegmentEnd?.name ?? "Destination")
                                 ProgressLiveActivityManager.shared.startActivity(
                                     totalDistance: 0,
                                     stage: RouteStage.waitingForBus.rawValue,
@@ -84,10 +88,11 @@ struct RouteSelectButton: View {
                 
                 if let selectedJourney = JourneyManager.shared.selectedJourney {
                     if case let .walk(node) = selectedJourney.nodes.first{
+                        let destination = languageCode == "ko" ? node.end.name : node.end.englishName ?? node.end.name
                         ProgressLiveActivityManager.shared.startActivity(
                             totalDistance: Double(WalkingViewModel().tmapTotalDistance),
                             stage: RouteStage.walkingToDestination.rawValue,
-                            destination: node.end.name,
+                            destination: destination,
                             remainingBusStops: 0,
                             timeTillBusArrival: 0
                         )

--- a/BusRoad/Feature/BeforeRide/BeforeRideView.swift
+++ b/BusRoad/Feature/BeforeRide/BeforeRideView.swift
@@ -9,7 +9,9 @@ struct BeforeRideView: View {
     @StateObject private var viewModel = BeforeRideViewModel()
     @EnvironmentObject private var coordinator: NavigationCoordinator
     @EnvironmentObject var proximityManager: AlightProximityManager
-    
+
+    private let languageCode = Locale.current.language.languageCode?.identifier
+
     var body: some View {
         
         ZStack {
@@ -83,9 +85,10 @@ struct BeforeRideView: View {
                                             
                                         if let index = viewModel.index, let journey = viewModel.journey,
                                             case let .bus(busnode) = journey.nodes[index] {
+                                            let destination = languageCode == "ko" ? busnode.end.name : busnode.end.englishName ?? busnode.end.name
                                             await ProgressLiveActivityManager.shared.updateStage(
                                                 nextStage: RouteStage.onBus.rawValue,
-                                                nextDestination: busnode.end.name,
+                                                nextDestination: destination,
                                                 totalDistance: 10,
                                                 remainingBusStops: proximityManager.remainingStations,
                                                 timeTillBusArrival: ArrivalInfoManager.shared.lastNearestArrTime ?? 0
@@ -134,9 +137,10 @@ struct BeforeRideView: View {
                                     
                                     if let index = viewModel.index, let journey = viewModel.journey,
                                         case let .bus(busnode) = journey.nodes[index] {
+                                        let destination = languageCode == "ko" ? busnode.end.name : busnode.end.englishName ?? busnode.end.name
                                         await ProgressLiveActivityManager.shared.updateStage(
                                             nextStage: RouteStage.onBus.rawValue,
-                                            nextDestination: busnode.end.name,
+                                            nextDestination: destination,
                                             totalDistance: 10,
                                             remainingBusStops: proximityManager.remainingStations,
                                             timeTillBusArrival: ArrivalInfoManager.shared.lastNearestArrTime ?? 0
@@ -178,15 +182,16 @@ struct BeforeRideView: View {
                 case let .bus(busNode) = journey.nodes[index] {
                 
                 // Live Activity를 waitingForBus 단계로 업데이트하는 로직 추가
+                let destination = languageCode == "ko" ? busNode.start.name : busNode.start.englishName ?? busNode.start.name
                 Task {
                     await ProgressLiveActivityManager.shared.updateStage(
                         nextStage: "waitingForBus", // RouteStage.waitingForBus.rawValue
-                        nextDestination: busNode.start.name,  // 승차 정류장 이름
+                        nextDestination: destination,  // 승차 정류장 이름
                         totalDistance: 0,
-                        remainingBusStops: proximityManager.remainingStations, 
+                        remainingBusStops: proximityManager.remainingStations,
                         timeTillBusArrival: ArrivalInfoManager.shared.lastNearestArrTime ?? 0
                     )
-                    print("[DEBUG] BeforeRideView - Live Activity waitingForBus 업데이트 완료. Destination: \(busNode.start.name)")
+                    print("[DEBUG] BeforeRideView - Live Activity waitingForBus 업데이트 완료. Destination: \(destination)")
                 }
             }
             print("[BeforeRideView] 정류장 추적 시작")

--- a/BusRoad/Feature/OnRide/OnRideView.swift
+++ b/BusRoad/Feature/OnRide/OnRideView.swift
@@ -4,7 +4,9 @@ struct OnRideView: View {
     @StateObject private var viewModel = OnRideViewModel()
     @EnvironmentObject private var coordinator: NavigationCoordinator
     @EnvironmentObject var proximityManager: AlightProximityManager
-    
+
+    private let languageCode = Locale.current.language.languageCode?.identifier
+
     var body: some View {
         ZStack {
             Color(.primarywhite)
@@ -64,7 +66,7 @@ struct OnRideView: View {
                                 switch nextNode {
                                 case .bus(let busNode):
                                     // 다음 버스 기다리는 상태
-                                    let boardingStopName = busNode.start.name
+                                    let boardingStopName = languageCode == "ko" ? busNode.start.name : busNode.start.englishName ?? busNode.start.name
                                     Task {
                                         await ProgressLiveActivityManager.shared.updateStage(
                                             nextStage: RouteStage.waitingForBus.rawValue,
@@ -75,32 +77,33 @@ struct OnRideView: View {
                                         )
                                     }
                                     print("[DEBUG] OnRideView - 환승 waitingForBus 업데이트, destination: \(boardingStopName)")
-                                    
+
                                 case .walk(let walkNode):
+                                    let walkDestination = languageCode == "ko" ? walkNode.end.name : walkNode.end.englishName ?? walkNode.end.name
                                     if nextIndex == journey.nodes.count - 1 {
                                         // 마지막 도보 → 목적지
                                         Task {
                                             await ProgressLiveActivityManager.shared.updateStage(
                                                 nextStage: RouteStage.walkingToDestination.rawValue,
-                                                nextDestination: walkNode.end.name,
+                                                nextDestination: walkDestination,
                                                 totalDistance: Double(WalkingViewModel().tmapTotalDistance),
                                                 remainingBusStops: 0,
                                                 timeTillBusArrival: 0
                                             )
                                         }
-                                        print("[DEBUG] OnRideView - walkingToDestination 업데이트, destination: \(walkNode.end.name)")
+                                        print("[DEBUG] OnRideView - walkingToDestination 업데이트, destination: \(walkDestination)")
                                     } else {
                                         // 환승을 위한 도보 → 다음 승차 정류장
                                         Task {
                                             await ProgressLiveActivityManager.shared.updateStage(
                                                 nextStage: RouteStage.walkingToBus.rawValue,
-                                                nextDestination: walkNode.end.name,
+                                                nextDestination: walkDestination,
                                                 totalDistance: Double(WalkingViewModel().tmapTotalDistance),
                                                 remainingBusStops: 0,
                                                 timeTillBusArrival: 0
                                             )
                                         }
-                                        print("[DEBUG] OnRideView - 환승 walkingToBus 업데이트, destination: \(walkNode.end.name)")
+                                        print("[DEBUG] OnRideView - 환승 walkingToBus 업데이트, destination: \(walkDestination)")
                                     }
                                 }
                             } label: {

--- a/BusRoad/Feature/Walking/WalkingView.swift
+++ b/BusRoad/Feature/Walking/WalkingView.swift
@@ -80,8 +80,8 @@ struct WalkingView: View {
                                             
                                             if journey.nodes.indices.contains(index + 1),
                                                case let .bus(busnode) = journey.nodes[index + 1] {
-                                                let boardingStopName = busnode.start.name
-                                                
+                                                let boardingStopName = languageCode == "ko" ? busnode.start.name : busnode.start.englishName ?? busnode.start.name
+
                                                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                                                     Task {
                                                         await ProgressLiveActivityManager.shared.updateStage(


### PR DESCRIPTION
## #️⃣ 관련 이슈
> closes #298 

---

## 💻 작업 내용

> 영어 설정 시 라이브 액티비티 영어정류장명 전달

---

## 📝 코드 설명

> languageCode 확인해서 한국어가 아닐 경우에는 englishName을 전달하도록 했습니다.

---

## 🙋 리뷰 요구사항

> 

---

## 📁 참고한 내용 (선택)
* (주소 첨부)
* 
---

## ✋🏻 잠깐! 확인하셨나요?
- [x] 컨벤션 확인
- [x] 기능 정상 작동 테스트 완료
- [x] 디버깅 코드 및 주석 제거
- [x] 사용하지 않는 코드/파일 정리
- [x] 작업 내용 및 코드 설명 작성 

