### PR TITLE
[Fix] 현지화 시 도착예정정보 없음 수정

### DIFF
--- a/BusRoad/Component/RouteSuggestionView/BoardingLocation.swift
+++ b/BusRoad/Component/RouteSuggestionView/BoardingLocation.swift
@@ -34,20 +34,20 @@ struct BoardingLocation: View {
                     .font(.premed16Scaled)
                     .foregroundColor(Color.greyNormal)
                 
-                HStack(spacing: 8.wScaled) {
+                HStack(alignment: .lastTextBaseline, spacing: 8.wScaled) {
                     if let info = nearestBusInfo {
                         Text(info.busNo)
                             .font(.presemi24Scaled)
                             .foregroundColor(.primaryHeavy)
                         Text(info.arrivalText)
-                            .font(.prereg16Scaled)
+                            .font(.prereg12Scaled)
                             .foregroundColor(Color.greyNormal)
                     } else {
                             Text(route.busNo[0])
                                 .font(.presemi24Scaled)
                                 .foregroundColor(.greyHeavy)
                             Text("도착 예정 정보 없음")
-                                .font(.prereg16Scaled)
+                                .font(.prereg12Scaled)
                                 .foregroundColor(Color.greyNormal)
                     }
                 }

--- a/BusRoad/Feature/RouteSuggestion/BusRouteViewModel.swift
+++ b/BusRoad/Feature/RouteSuggestion/BusRouteViewModel.swift
@@ -397,9 +397,9 @@ extension BusRouteViewModel {
         let minutes = item.arrtime / 60
         let arrivalText: String
         if minutes < 1 {
-            arrivalText = "곧 도착"
+            arrivalText = String(localized: "곧 도착")
         } else {
-            arrivalText = "\(minutes)분 후"
+            arrivalText = String(localized: "\(minutes)분 후")
         }
         
         self.arrivalText = arrivalText

--- a/BusRoad/Resource/Font/FontResource.swift
+++ b/BusRoad/Resource/Font/FontResource.swift
@@ -245,6 +245,10 @@ extension Font {
         return .preScaled(type: .regular, size: 16)
     }
     
+    static var prereg12Scaled: Font {
+        return .preScaled(type: .regular, size: 12)
+    }
+    
     // 페이퍼로지 - 스케일링 버전
     static var papersemi36Scaled: Font {
         return .paperScaled(type: .semibold, size: 36)

--- a/BusRoad/Utility/Manager/ArrivalInfoManager.swift
+++ b/BusRoad/Utility/Manager/ArrivalInfoManager.swift
@@ -241,16 +241,17 @@ final class ArrivalInfoManager: ObservableObject {
             }
             
             // 필터링 및 결과 처리
+            let targetBusNumbers = busRouteNode.busNo.map { cleanBusNumber($0) }
             let filtered = allArrivals.filter { arrival in
-                busRouteNode.busNo.contains(cleanBusNumber(arrival.routeno))
+                targetBusNumbers.contains(cleanBusNumber(arrival.routeno))
             }
-            
+
             print("[ArrivalInfoManager] 조회 결과: \(filtered.map { "\(cleanBusNumber($0.routeno)) - \($0.arrtime)s" })")
-            
+
             if filtered.isEmpty {
                 if let lastItem = lastNearestItem {
                     let lastNo = cleanBusNumber(lastItem.routeno)
-                    if busRouteNode.busNo.contains(lastNo) {
+                    if targetBusNumbers.contains(lastNo) {
                         print("[ArrivalInfoManager] 리스트에서 사라짐 → 지나감")
                         let passed = lastItem
                         clearTracking()

--- a/BusRoad/Utility/Manager/ArrivalInfoManager.swift
+++ b/BusRoad/Utility/Manager/ArrivalInfoManager.swift
@@ -450,7 +450,9 @@ final class ArrivalInfoManager: ObservableObject {
     
     private func updateUI(with item: BusArrivalItem) {
         let minutes = item.arrtime / 60
-        let text = minutes < 1 ? "곧 도착" : "\(minutes)분 후"
+        let text = minutes < 1
+            ? String(localized: "곧 도착")
+            : String(localized: "\(minutes)분 후")
         let wasArrivingSoon = isArrivingSoon
         
         isArrivingSoon = minutes < 2
@@ -538,14 +540,15 @@ final class ArrivalInfoManager: ObservableObject {
                 )
             }
             
+            let targetBusNumbers = busRouteNode.busNo.map { cleanBusNumber($0) }
             let filtered = allArrivals.filter { arrival in
-                busRouteNode.busNo.contains(cleanBusNumber(arrival.routeno))
+                targetBusNumbers.contains(cleanBusNumber(arrival.routeno))
             }
-            
+
             if let nearest = filtered.min(by: { $0.arrtime < $1.arrtime }) {
                 return nearest
             }
-            
+
             return nil
             
         } catch {

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -37,6 +37,16 @@
         }
       }
     },
+    "%lld분 후" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld min"
+          }
+        }
+      }
+    },
     "%lld정류장 " : {
       "localizations" : {
         "en" : {


### PR DESCRIPTION
## #️⃣ 관련 이슈
> closes #303  

---

## 💻 작업 내용

- [x] 시스템 언어 설정이 한국어 이외(영어)일 시, 도착 예정 정보가 불러와지지 않는 오류 수정
- [x] UI에서 버스번호와 도착정보 텍스트 아래정렬, 폰트 크기 변경(피그마 참고함)

---

## 📝 코드 설명

> 기존 코드에서는 다음과 같은 오류가 있었습니다.
1. 도착 예정 정보 텍스트(ex. 12분 후, 잠시 후, 도착예정정보 없음)가 Text()에 할당이 아니라 String 변수에 직접 할당되어 자동 현지화가 되지 않는 이슈
2. 현지화를 하면서 140번 -> 140 으로 '번'이 삭제되었는데, 도착예정정보를 볼 버스정보는 여전히 '140번'으로 저장되어 있어 매칭이 되지 않는 오류

따라서, **자동 로컬라이제이션이 되도록 텍스트 코드를 수정 + `cleanBusNumber()` 함수를 이용하여 매칭되도록 수정**하여 오류를 해결하였습니다.

추가로 UI 상으로 피그마와 일부 맞지 않는 디자인을 발견하여 폰트 크기와 아래정렬을 맞췄습니다.

---

## 🙋 리뷰 요구사항

> 
<img width="590" height="1278" alt="IMG_2284" src="https://github.com/user-attachments/assets/b0ae1c50-bfb6-4a0b-8141-e8580a59b87d" />


---

## 📁 참고한 내용 (선택)
* (주소 첨부)
* 
---

## ✋🏻 잠깐! 확인하셨나요?
- [ ] 컨벤션 확인
- [ ] 기능 정상 작동 테스트 완료
- [ ] 디버깅 코드 및 주석 제거
- [ ] 사용하지 않는 코드/파일 정리
- [ ] 작업 내용 및 코드 설명 작성 

