### PR TITLE
Feat/#288/local info

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -740,6 +740,17 @@
         }
       }
     },
+    "버스 하차 알림" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bus exit alerts"
+          }
+        }
+      }
+    },
     "번" : {
       "comment" : "번",
       "localizations" : {
@@ -779,17 +790,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bus"
-          }
-        }
-      }
-    },
-    "버스 하차 알림" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bus exit alerts"
           }
         }
       }
@@ -849,7 +849,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Voice alerts are muted in Silent Mode"
+            "value" : "Voice alerts mute in Silent Mode"
           }
         }
       }

--- a/ProgressWidget/ProgressLiveActivityManager.swift
+++ b/ProgressWidget/ProgressLiveActivityManager.swift
@@ -62,7 +62,8 @@ final class ProgressLiveActivityManager {
         }
         
         // splitTextToFit을 static 함수로 변경하여 호출
-        let adjustedText = splitTextToFit(text: baseText, maxCharactersPerLine: 16)
+        let maxCount = isEnglish(text: baseText) ? 26 : 16
+        let adjustedText = splitTextToFit(text: baseText, maxCharactersPerLine: maxCount)
         
         return adjustedText.replacingOccurrences(of: " ", with: "\u{00a0}")
     }
@@ -88,6 +89,13 @@ final class ProgressLiveActivityManager {
     }
     
     // static 함수로 변경
+    private static func isEnglish(text: String) -> Bool {
+        for scalar in text.unicodeScalars {
+            if !(scalar.value < 128) { return false }
+        }
+        return true
+    }
+
     private static func splitTextToFit(text: String, maxCharactersPerLine: Int) -> String {
         guard text.count > maxCharactersPerLine else {
             return text // 1줄이면 그대로 반환


### PR DESCRIPTION
## #️⃣ 관련 이슈
> closes #288 

---

## 💻 작업 내용

> qa에서 나온 설명창 인포 박스 크기가 창을 넘어가는 문제를 해결하기 위해 해당 문구를 축소하였습니다. (Voice alerts **are muted** in Silent Mode -> Voice alerts **mute** in Silent Mode)
아래 글꼴 크기 최소/최대일 때 화면 첨부합니다.

<img width="590" height="1278" alt="IMG_2598" src="https://github.com/user-attachments/assets/f96242d4-c435-475b-a6c5-cdad5cbc5a4d" />

<img width="590" height="1278" alt="IMG_2599" src="https://github.com/user-attachments/assets/c7d0ec0f-b918-4c37-b8db-055fc01762cd" />

---

## 📝 코드 설명

> 문구만 변경했습니다

---

## 🙋 리뷰 요구사항

> 리뷰어에게 특별히 봐줬으면 하는 부분을 적어주세요.

ex. 이 부분의 코드가 잘 작동하는지 체크해주실 수 있나요?

---

## 📁 참고한 내용 (선택)
* (주소 첨부)
* 
---

## ✋🏻 잠깐! 확인하셨나요?
- [ ] 컨벤션 확인
- [ ] 기능 정상 작동 테스트 완료
- [ ] 디버깅 코드 및 주석 제거
- [ ] 사용하지 않는 코드/파일 정리
- [ ] 작업 내용 및 코드 설명 작성 

