### PR TITLE
Fix/#306/qa

### DIFF
--- a/BusRoad/Component/BeforeRideView/BeforeRideCard.swift
+++ b/BusRoad/Component/BeforeRideView/BeforeRideCard.swift
@@ -62,6 +62,8 @@ struct BeforeRideCard: View {
                         Text(info.busNo)
                             .font(.presemi32Scaled)
                             .foregroundStyle(viewModel.isArrivingSoon ? .primaryHeavy : .subLight)
+                            .lineLimit(1)
+                            .fixedSize(horizontal: true, vertical: false)
                             .padding(.horizontal, 8.wScaled)
                             .padding(.vertical, 4.wScaled)
                             .background(
@@ -85,6 +87,8 @@ struct BeforeRideCard: View {
                         Text(waitingBusNo[0])
                             .font(.presemi32Scaled)
                             .foregroundStyle(.subLight)
+                            .lineLimit(1)
+                            .fixedSize(horizontal: true, vertical: false)
                             .padding(.horizontal, 8.wScaled)
                             .padding(.vertical, 4.wScaled)
                             .background(

--- a/BusRoad/Component/Common/StopNavigationAlert.swift
+++ b/BusRoad/Component/Common/StopNavigationAlert.swift
@@ -25,7 +25,7 @@ struct StopNavigationAlert: View {
             .padding(.top, 20.wScaled)
             .padding(.bottom, 10.wScaled)
             
-          Text("페이지를 나가면 경로 안내가\n종료돼요.")
+          Text("페이지를 나가면 경로 안내가\n종료돼요")
             .font(.prereg20Scaled)
             .foregroundColor(.primaryblack)
            .multilineTextAlignment(.center)

--- a/BusRoad/Component/OnRideView/OnRideCard.swift
+++ b/BusRoad/Component/OnRideView/OnRideCard.swift
@@ -50,7 +50,7 @@ struct OnRideCard: View {
                 VStack(spacing: 11 .wScaled) {
                     HStack {
                         if canAlight {
-                            Text("이번 정류장에서 내리세요.")
+                            Text("이번 정류장에서 내리세요")
                                 .font(.presemi20Scaled)
                                 .foregroundStyle(canAlight ? .subNormal : .primaryStrong)
                         } else {

--- a/BusRoad/Component/WalkingView/AtArrival.swift
+++ b/BusRoad/Component/WalkingView/AtArrival.swift
@@ -33,7 +33,7 @@ struct AtArrival: View {
                         .font(.prereg24Scaled)
                         .foregroundColor(.primaryHeavy)
                     
-                    Text("확인해주세요.")
+                    Text("확인해주세요")
                         .font(.prereg24Scaled)
                         .foregroundColor(.primaryHeavy)
                 }

--- a/BusRoad/Component/WalkingView/ToDestination.swift
+++ b/BusRoad/Component/WalkingView/ToDestination.swift
@@ -43,7 +43,7 @@ struct ToDestination: View {
                         .foregroundColor(.primaryHeavy)
                         .monospacedDigit()
                     
-                    Text("남았어요.")
+                    Text("남았어요")
                         .font(.prereg32Scaled)
                         .foregroundColor(.primaryHeavy)
                 }

--- a/BusRoad/Feature/MainSearch/MainSearchViewModel.swift
+++ b/BusRoad/Feature/MainSearch/MainSearchViewModel.swift
@@ -15,7 +15,7 @@ final class MainSearchViewModel: ObservableObject {
             UserDefaults.standard.set(hasShownVoiceHint, forKey: kHasShownVoiceHint)
         }
     }
-    let store = LocationStore()
+    let store = LocationStore.shared
     
     private let kHasShownVoiceHint = "hasShownVoiceHint_v1"
     private let languageCode = Locale.current.language.languageCode?.identifier

--- a/BusRoad/Feature/MainSearch/SubView/IntroSection.swift
+++ b/BusRoad/Feature/MainSearch/SubView/IntroSection.swift
@@ -27,7 +27,7 @@ struct IntroSection: View {
                             .frame(width: 30.wScaled, height: 30.wScaled)
                     }
                 }
-                .padding(.top, 44)
+                .padding(.top, 55)
                 .padding(.horizontal, 16)
                 
                 Spacer()

--- a/BusRoad/Feature/MainSearch/SubView/SearchModeSection.swift
+++ b/BusRoad/Feature/MainSearch/SubView/SearchModeSection.swift
@@ -126,10 +126,10 @@ struct SearchModeSection: View {
                         Spacer(minLength: 0)
                         
                         VStack(spacing: 6) {
-                            Text("검색 결과가 없어요.")
+                            Text("검색 결과가 없어요")
                                 .font(.presemi24)
                                 .foregroundStyle(.greyHeavy)
-                            Text("찾고 있는 장소를 다시 검색해 주세요.")
+                            Text("찾고 있는 장소를 다시 검색해 주세요")
                                 .font(.prereg20)
                                 .foregroundStyle(.greyHeavy)
                         }

--- a/BusRoad/Feature/RouteSuggestion/BusRouteViewModel.swift
+++ b/BusRoad/Feature/RouteSuggestion/BusRouteViewModel.swift
@@ -155,10 +155,11 @@ class BusRouteViewModel: ObservableObject {
                     return
                 }
                 
-                if let jsonString = String(data: data, encoding: .utf8) {
-                    print("📬 [ODsay API 응답 원본]")
-                    print(jsonString)
-                }
+                // 원본 JSON 출력 주석처리
+//                if let jsonString = String(data: data, encoding: .utf8) {
+//                    print("📬 [ODsay API 응답 원본]")
+//                    print(jsonString)
+//                }
                 
                 do {
                     if let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] {

--- a/BusRoad/Feature/RouteSuggestion/BusRouteViewModel.swift
+++ b/BusRoad/Feature/RouteSuggestion/BusRouteViewModel.swift
@@ -433,11 +433,12 @@ extension BusRouteViewModel {
             }
         }
         
-        // 숫자로 끝날 경우 "번" 추가
-        if let lastChar = result.last, lastChar.isNumber {
+        // 한국어일 때만 숫자로 끝날 경우 "번" 추가
+        let isKorean = Locale.current.language.languageCode?.identifier == "ko"
+        if isKorean, let lastChar = result.last, lastChar.isNumber {
             result += NSLocalizedString("번", comment: "번")
         }
-        
+
         return result.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }

--- a/BusRoad/Feature/RouteSuggestion/BusRouteViewModel.swift
+++ b/BusRoad/Feature/RouteSuggestion/BusRouteViewModel.swift
@@ -32,7 +32,7 @@ class BusRouteViewModel: ObservableObject {
     @Published var isRefreshingLocation: Bool = false
     
     
-    let store = LocationStore()
+    let store = LocationStore.shared
     private let journeyManager: JourneyManager
     private let searchManager: SearchManager
     private let arrivalInfoManager: ArrivalInfoManager

--- a/BusRoad/Feature/Setting/SettingsView.swift
+++ b/BusRoad/Feature/Setting/SettingsView.swift
@@ -35,7 +35,10 @@ struct SettingsView: View {
                                 .aspectRatio(contentMode: .fit)
                                 .frame(width: 20.wScaled, height: 20.wScaled)
                                 .foregroundColor(.greyNormal)
+                                .padding(12.wScaled)
+                                .contentShape(Rectangle())
                         }
+                        .padding(-12.wScaled)
                         Spacer()
                     }
                     

--- a/BusRoad/Feature/Setting/SettingsView.swift
+++ b/BusRoad/Feature/Setting/SettingsView.swift
@@ -153,7 +153,7 @@ struct SettingsView: View {
                     VStack(alignment: .leading) {
                         Spacer()
                         
-                        Text("아이폰 무음 모드가 켜져 있으면 음성 알림이\n들리지 않아요.")
+                        Text("아이폰 무음 모드가 켜져 있으면 음성 알림이\n들리지 않아요")
                             .font(.premed14)
                             .foregroundStyle(.primaryblack)
                     }
@@ -165,7 +165,7 @@ struct SettingsView: View {
                     .buttonStyle(.plain)
                 }
                 
-                Text("음성 알림을 들으려면 무음 모드를 해제해주세요.")
+                Text("음성 알림을 들으려면 무음 모드를 해제해주세요")
                     .font(.prereg14)
                     .foregroundStyle(.primaryblack)
             }

--- a/BusRoad/Feature/VoiceSearch/VoiceSearchViewModel.swift
+++ b/BusRoad/Feature/VoiceSearch/VoiceSearchViewModel.swift
@@ -217,17 +217,17 @@ extension VoiceSearchViewModel {
     var centerMessage: String {
         switch state {
         case .ready:
-            return NSLocalizedString("원하는 장소를 말해보세요.", comment: "원하는 장소를 말해보세요.")
+            return NSLocalizedString("원하는 장소를 말해보세요", comment: "원하는 장소를 말해보세요.")
         case .listening:
             // 듣는 중에도 실시간으로 인식된 텍스트 표시
-            return recognizedText.isEmpty ? NSLocalizedString("원하는 장소를 말해보세요.", comment: "원하는 장소를 말해보세요.") : recognizedText
+            return recognizedText.isEmpty ? NSLocalizedString("원하는 장소를 말해보세요", comment: "원하는 장소를 말해보세요.") : recognizedText
         case .processing:
             return recognizedText.isEmpty ? "" : recognizedText
         case .completed:
             return recognizedText
         case .failed:
 //            return "마이크를 눌러서 다시 말해주세요."
-            return recognizedText.isEmpty ? NSLocalizedString("마이크를 눌러서 다시 말해주세요.", comment: "마이크를 눌러서 다시 말해주세요.") : recognizedText
+            return recognizedText.isEmpty ? NSLocalizedString("마이크를 눌러서 다시 말해주세요", comment: "마이크를 눌러서 다시 말해주세요.") : recognizedText
         }
     }
     

--- a/BusRoad/Feature/Walking/WalkingViewModel.swift
+++ b/BusRoad/Feature/Walking/WalkingViewModel.swift
@@ -91,9 +91,9 @@ final class WalkingViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
             self.journeyIndex = index
             
             if index == journey.nodes.count - 1 {
-                arrivalDistance = 6
+                arrivalDistance = 10
             } else {
-                arrivalDistance = 12
+                arrivalDistance = 15
             }
         }
         

--- a/BusRoad/Utility/Manager/ArrivalInfoManager.swift
+++ b/BusRoad/Utility/Manager/ArrivalInfoManager.swift
@@ -163,33 +163,27 @@ final class ArrivalInfoManager: ObservableObject {
     
     func refreshNearestBusArrival(for busRouteNode: BusRouteNode)
     async -> (item: BusArrivalItem?, didPass: Bool, passedBus: BusArrivalItem?) {
-        
-        let busLocation = busRouteNode.start
-        
-        guard let cityCode = await CityCodeManager.shared.getCityCodeByLocationAsync(
-            latitude: busLocation.latitude,
-            longitude: busLocation.longitude
-        ) else {
-            print("[ArrivalInfoManager] 도시코드 찾기 실패")
-            return (nil, false, nil)
-        }
-        
-        lastCityCode = cityCode
-        let busService = BusServiceFactory.create(cityCode: cityCode)
-        
+
+        // 먼저 승차 정류장 확인
         guard let firstStation = busRouteNode.stations.first else {
             print("[ArrivalInfoManager] 정류장 정보 없음")
             return (nil, false, nil)
         }
-        
-        
+
+        // 승차 정류장의 도시 코드 사용 (출발지가 아닌 정류장 기준)
+        let cityCode = firstStation.stationCityCode
+        let isSeoul = BusServiceFactory.isSeoul(cityCode: cityCode)
+        print("[ArrivalInfoManager] 승차정류장: \(firstStation.stationName), cityCode: \(cityCode), isSeoul: \(isSeoul)")
+        lastCityCode = cityCode
+        let busService = BusServiceFactory.create(cityCode: cityCode)
+
         var allArrivals: [BusArrivalItem] = []
         
         
         
         do {
-            // 서울시 로직
-            if cityCode == 1000, let seoulService = busService as? SeoulBusService {
+            // 서울시 로직 (cityCode 1000 또는 구 단위 11xx)
+            if BusServiceFactory.isSeoul(cityCode: cityCode), let seoulService = busService as? SeoulBusService {
 
                 let stationName = firstStation.stationName
                 guard let stId = firstStation.localStationId else {
@@ -220,8 +214,18 @@ final class ArrivalInfoManager: ObservableObject {
                         print("[Manager] CSV 매칭 실패: stId(\(stId)) bus(\(cleanedBusNo))")
                     }
                 }
+
+                // 서울 API에서 결과 없으면 경기도 API로 fallback (서울 정류장에서 경기도 버스 탑승 시)
+                if allArrivals.isEmpty {
+                    print("[Manager] 서울 API 결과 없음, 경기도 API로 fallback")
+                    let gyeonggiService = GyeonggiBusService()
+                    allArrivals = try await gyeonggiService.fetchBusArrivalInfo(
+                        cityCode: 31010,
+                        nodeId: stId
+                    )
+                }
             }
-            
+
             else {
                 var nodeId = ""
                 if let local = firstStation.localStationId {
@@ -488,39 +492,54 @@ final class ArrivalInfoManager: ObservableObject {
     // MARK: - 도착 정보 요약
     
     func prepareRouteArrivalSummary(for busRouteNode: BusRouteNode) async -> BusArrivalItem? {
-        let busLocation = busRouteNode.start
-        
-        guard let cityCode = await CityCodeManager.shared.getCityCodeByLocationAsync(
-            latitude: busLocation.latitude,
-            longitude: busLocation.longitude
-        ) else {
+        // 승차 정류장 확인
+        guard let station = busRouteNode.stations.first else {
+            print("[prepareRouteArrivalSummary] 정류장 없음")
             return nil
         }
-        
+
+        // 승차 정류장의 도시 코드 사용 (출발지가 아닌 정류장 기준)
+        let cityCode = station.stationCityCode
+        let isSeoul = BusServiceFactory.isSeoul(cityCode: cityCode)
+        let isGyeonggi = BusServiceFactory.isGyeonggi(cityCode: cityCode)
+        print("[prepareRouteArrivalSummary] 정류장: \(station.stationName), cityCode: \(cityCode), isSeoul: \(isSeoul), isGyeonggi: \(isGyeonggi)")
         let busService = BusServiceFactory.create(cityCode: cityCode)
-        guard let station = busRouteNode.stations.first else { return nil }
         
         var allArrivals: [BusArrivalItem] = []
         
         do {
-            if cityCode == 1000, let seoulService = busService as? SeoulBusService {
-                
+            if BusServiceFactory.isSeoul(cityCode: cityCode), let seoulService = busService as? SeoulBusService {
+
                 let stationName = station.stationName
                 let stId = station.localStationId
-                
+                print("[prepareRouteArrivalSummary] 서울 API 사용, stId: \(stId ?? "nil"), busNo: \(busRouteNode.busNo)")
+
                 for targetBusNo in busRouteNode.busNo {
                     if let info = BusDataManager.shared.findTargetRouteInfo(
                         stId: stId,
                         stationName: stationName,
                         busName: targetBusNo
                     ) {
+                        print("[prepareRouteArrivalSummary] CSV 매칭 성공: \(targetBusNo)")
                         let items = try await seoulService.fetchBusArrivalByRoute(
                             stId: info.stId,
                             busRouteId: info.routeId,
                             ord: info.ord
                         )
                         allArrivals.append(contentsOf: items)
+                    } else {
+                        print("[prepareRouteArrivalSummary] CSV 매칭 실패: \(targetBusNo)")
                     }
+                }
+
+                // 서울 API에서 결과 없으면 경기도 API로 fallback (서울 정류장에서 경기도 버스 탑승 시)
+                if allArrivals.isEmpty, let nodeId = stId {
+                    print("[prepareRouteArrivalSummary] 서울 API 결과 없음, 경기도 API로 fallback")
+                    let gyeonggiService = GyeonggiBusService()
+                    allArrivals = try await gyeonggiService.fetchBusArrivalInfo(
+                        cityCode: 31010, // 경기도 기본 코드
+                        nodeId: nodeId
+                    )
                 }
             }
             else {
@@ -534,7 +553,7 @@ final class ArrivalInfoManager: ObservableObject {
                         arsId: nil
                     )
                 }
-                
+
                 allArrivals = try await busService.fetchBusArrivalInfo(
                     cityCode: cityCode,
                     nodeId: nodeId

--- a/BusRoad/Utility/Manager/ArrivalInfoManager.swift
+++ b/BusRoad/Utility/Manager/ArrivalInfoManager.swift
@@ -474,7 +474,9 @@ final class ArrivalInfoManager: ObservableObject {
         while let _ = result.range(of: pattern, options: .regularExpression) {
             result = result.replacingOccurrences(of: pattern, with: "", options: .regularExpression)
         }
-        if let last = result.last, last.isNumber {
+        // 한국어일 때만 "번" 추가
+        let isKorean = Locale.current.language.languageCode?.identifier == "ko"
+        if isKorean, let last = result.last, last.isNumber {
             result += "번"
         }
         return result.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/BusRoad/Utility/Manager/JourneyManager.swift
+++ b/BusRoad/Utility/Manager/JourneyManager.swift
@@ -297,14 +297,15 @@ final class JourneyManager: ObservableObject {
             }
         }
         
-        // 숫자로 끝날 경우 "번" 추가
-        if let lastChar = result.last, lastChar.isNumber {
+        // 한국어일 때만 숫자로 끝날 경우 "번" 추가
+        let isKorean = Locale.current.language.languageCode?.identifier == "ko"
+        if isKorean, let lastChar = result.last, lastChar.isNumber {
             result += NSLocalizedString("번", comment: "번")
         }
-        
+
         return result.trimmingCharacters(in: .whitespacesAndNewlines)
     }
-    
+
     /// 이전 노드의 end와 다음 노드의 start가 이름/좌표 모두 '완전히 동일'한지 검사
     private func isSameStopStrict(prev: [String: Any], next: [String: Any]) -> Bool {
         guard

--- a/BusRoad/Utility/Service/BusService/BusServiceFactory.swift
+++ b/BusRoad/Utility/Service/BusService/BusServiceFactory.swift
@@ -2,13 +2,19 @@ import Foundation
 
 class BusServiceFactory {
 
-    // 경기도 cityCode 범위: 31010 ~ 31380
+    // 경기도 cityCode 범위 (공공데이터포털): 31010 ~ 31380
     private static let gyeonggiCityCodeRange = 31010...31380
 
+    // 경기도 cityCode 범위 (ODsay API): 1001 ~ 1099 (1010 성남, 1020 수원 등)
+    private static let odsayGyeonggiCityCodeRange = 1001...1099
+
+    // 서울 구 단위 cityCode 범위: 1100 ~ 1199 (강남구 1168, 강북구 1130 등)
+    private static let seoulDistrictCodeRange = 1100...1199
+
     static func create(cityCode: Int) -> BusServiceType {
-        if cityCode == 1000 {
+        if cityCode == 1000 || seoulDistrictCodeRange.contains(cityCode) {
             return SeoulBusService()
-        } else if gyeonggiCityCodeRange.contains(cityCode) {
+        } else if gyeonggiCityCodeRange.contains(cityCode) || odsayGyeonggiCityCodeRange.contains(cityCode) {
             return GyeonggiBusService()
         } else {
             return TagoBusService()
@@ -17,7 +23,12 @@ class BusServiceFactory {
 
     /// 경기도 지역인지 확인
     static func isGyeonggi(cityCode: Int) -> Bool {
-        return gyeonggiCityCodeRange.contains(cityCode)
+        return gyeonggiCityCodeRange.contains(cityCode) || odsayGyeonggiCityCodeRange.contains(cityCode)
+    }
+
+    /// 서울 지역인지 확인 (1000 또는 구 단위 코드 11xx)
+    static func isSeoul(cityCode: Int) -> Bool {
+        return cityCode == 1000 || seoulDistrictCodeRange.contains(cityCode)
     }
 }
 

--- a/BusRoad/Utility/Service/BusService/TagoBusService.swift
+++ b/BusRoad/Utility/Service/BusService/TagoBusService.swift
@@ -69,10 +69,10 @@ class TagoBusService: BusServiceType {
         let data = try await request(urlString: urlString, params: params)
         
         // 원본 JSON 출력 (디버깅용)
-        if let jsonString = String(data: data, encoding: .utf8) {
-            print("[도착정보 응답 원본 JSON]")
-            print(jsonString)
-        }
+//        if let jsonString = String(data: data, encoding: .utf8) {
+//            print("[도착정보 응답 원본 JSON]")
+//            print(jsonString)
+//        }
         
         let response = try JSONDecoder().decode(BusArrivalResponse.self, from: data)
         

--- a/BusRoad/Utility/Store/LocationStore.swift
+++ b/BusRoad/Utility/Store/LocationStore.swift
@@ -8,13 +8,15 @@ import SwiftUI
 import Combine
 
 class LocationStore: ObservableObject {
+    static let shared = LocationStore()
+
     @Published var locations: [PlaceSummary] = [] {
         didSet { save() }
     }
-    
+
     private let key = "savedLocations"
-    
-    init() {
+
+    private init() {
         load()
     }
     

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -401,7 +401,18 @@
         }
       }
     },
+    "검색 결과가 없어요" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No results found"
+          }
+        }
+      }
+    },
     "검색 결과가 없어요." : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -508,12 +519,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : " left"
+            "value" : "left"
           }
         }
       }
     },
     "남았어요." : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -689,6 +701,17 @@
         }
       }
     },
+    "마이크를 눌러서 다시 말해주세요" : {
+      "comment" : "마이크를 눌러서 다시 말해주세요.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap the microphone and try again"
+          }
+        }
+      }
+    },
     "마이크를 눌러서 다시 말해주세요." : {
       "extractionState" : "manual",
       "localizations" : {
@@ -725,7 +748,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Walk to the desstination"
+            "value" : "Walk to the destination"
           }
         }
       }
@@ -844,7 +867,18 @@
         }
       }
     },
+    "아이폰 무음 모드가 켜져 있으면 음성 알림이\n들리지 않아요" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voice alerts are muted in Silent Mode"
+          }
+        }
+      }
+    },
     "아이폰 무음 모드가 켜져 있으면 음성 알림이\n들리지 않아요." : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -884,6 +918,17 @@
         }
       }
     },
+    "원하는 장소를 말해보세요" : {
+      "comment" : "원하는 장소를 말해보세요.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Say the place you’re looking for."
+          }
+        }
+      }
+    },
     "원하는 장소를 말해보세요." : {
       "extractionState" : "manual",
       "localizations" : {
@@ -905,7 +950,18 @@
         }
       }
     },
+    "음성 알림을 들으려면 무음 모드를 해제해주세요" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Turn off Silent Mode to hear them"
+          }
+        }
+      }
+    },
     "음성 알림을 들으려면 무음 모드를 해제해주세요." : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -969,6 +1025,7 @@
       }
     },
     "이번 정류장에서 내리세요." : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -1058,7 +1115,18 @@
         }
       }
     },
+    "찾고 있는 장소를 다시 검색해 주세요" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Try searching another place"
+          }
+        }
+      }
+    },
     "찾고 있는 장소를 다시 검색해 주세요." : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -1138,7 +1206,18 @@
         }
       }
     },
+    "페이지를 나가면 경로 안내가\n종료돼요" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Navigation will end if you leave this page"
+          }
+        }
+      }
+    },
     "페이지를 나가면 경로 안내가\n종료돼요." : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -1210,7 +1289,11 @@
         }
       }
     },
+    "확인해주세요" : {
+
+    },
     "확인해주세요." : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -569,7 +569,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@ min walk"
+            "value" : "%@ walk"
           }
         }
       }


### PR DESCRIPTION
## #️⃣ 관련 이슈
> closes #306 

---

## 💻 작업 내용

- [x] 설정 버튼 위치 조정(X버튼과 같은 위치로 조정)
- [x] BeforeRideView '번' 삭제(영어 설정일 시)
- [ ] 검색 리스트 뷰 백스와이프(구현 불가)
- [x] 버스 번호 길 때 한 줄로만
- [x] 서울 -> 경기도 ETA 안 나오는 문제 해결
- [x] 5 min min walk -> 5 min walk
- [x] walkingView 정류장/목적지 도착 반경 12->15, 6->10 변경

---

## 📝 코드 설명

- 설정 버튼 위치 조정(x버튼과 같은 위치로)
: x버튼과 아이콘의 패딩이 조금 달라서, 눈대중으로 조금 아래로 내렸습니다.

- BeforeRideView '번' 삭제(영어 설정일 시)
: 영어 설정일 시에는 모든 코드에서 '번'을 붙이지 않는 것으로 수정했습니다.

- 검색 리스트 뷰 백스와이프(구현X)
: 이거는 UI상으로 봤을 때는 뒤로가기이지만, 사실 뷰 전환이 되는 구조라서 다른 뷰와는 달리 내비게이션 스택이 안 쌓입니다. 그래서 다른 뷰와는 달리 백스와이프 모션을 넣는 것이 힘들 것 같습니다(하려면 MainSearchView를 다시 설계해야 할 듯 합니다). 그리고 한다고 해도 위아래로 움직이는 제스처도 같이 있어서 두 제스처가 잘 작동할지 봐야 알 것 같습니다.

- 버스 번호 길 때 한 줄로만
: BeforeRideView에서 버스번호 길 때 두 줄로 나온다고 하셔서, 한 줄로만 나오게끔 코드 수정했습니다.

- 서울 -> 경기도 ETA 안 나오는 문제 해결
: 승차 정류장은 서울이라 도시코드가 서울인데, 경기도 버스인 경우가 존재했습니다. 그런 경우 fallback 처리하여 경기도 버스를 찾도록 수정했습니다.

- 5 min min walk -> 5 min walk
: 도보 번역에서 value를 %@ min walk가 아니라 %@ walk로 바꿨습니다.

- walkingView 정류장/목적지 도착 반경 12->15, 6->10 변경
: 원래 12m, 6m였던 것을 QA 요청에 따라 15m, 10m로 변경했습니다.

---

## 🙋 리뷰 요구사항

> 버스번호 4자리 수 이상일 때 원래 두 줄로 나오던 것 확인하셔서 한 줄이 잘리지는 않는지 확인 부탁드립니다.

---

## 📁 참고한 내용 (선택)
* (주소 첨부)
* 
---

## ✋🏻 잠깐! 확인하셨나요?
- [x] 컨벤션 확인
- [x] 기능 정상 작동 테스트 완료
- [ ] 디버깅 코드 및 주석 제거
- [x] 사용하지 않는 코드/파일 정리
- [x] 작업 내용 및 코드 설명 작성 

